### PR TITLE
Version 0.1.1

### DIFF
--- a/argo-scg.spec
+++ b/argo-scg.spec
@@ -4,7 +4,7 @@
 
 Summary:       ARGO Sensu configuration manager.
 Name:          argo-scg
-Version:       0.1.0
+Version:       0.1.1
 Release:       1%{?dist}
 Source0:       %{name}-%{version}.tar.gz
 License:       ASL 2.0
@@ -47,5 +47,37 @@ rm -rf $RPM_BUILD_ROOT
 %attr(0755,root,root) %dir %{_localstatedir}/log/argo-scg/
 
 %changelog
+* Thu Mar 2 2023 Katarina Zailac <kzailac@srce.hr> - 0.1.1-1%{?dist}
+- ARGO-4235 Remove regex validation of entity names
+- ARGO-4228 Create tool to acknowledge alerts
+- ARGO-4224 Skip configuration in case of data fetch error
+- ARGO-4223 Create a tool that is going to force run check for an entity
+- ARGO-4222 Create a tool that is going to display how exactly the probe is invoked
+- ARGO-4091Delete all the resources in the namespace when it is no longer used
+- ARGO-4215 Send entire metric output message to publisher
+- ARGO-4193 Log calls to ams-metric-to-queue tool
+- ARGO-4203 Send hostname_id in metric result
+- ARGO-4197 Skip creation of improperly formatted entities
+- ARGO-4189 Send metric output to ams
+- ARGO-4139 Possibility to override default arguments
+- ARGO-4137 Tool not creating "path" label for entity
+- ARGO-4092 Add topology filtering
+- ARGO-4090 The tool not creating labels for agent
+- ARGO-4098 Bug with metric parameter overrides
+- ARGO-4079 The tool not reporting missing metric configuration
+- ARGO-4047 Create tool for ad hoc check execution request
+- ARGO-4002 Remove hard-coded default ports
+- ARGO-4003 Handle hostnames in tags
+- ARGO-3999 Remove hard-coded list of secrets
+- ARGO-3986 Tool not handling *_URL attributes properly
+- ARGO-3956 Include filter mimicking hard/soft state to non-internal checks
+- ARGO-3945 Include internal checks for sensu agent
+- ARGO-3944 Improve filter for internal events
+- ARGO-3910 Improve logging when setting up the configuration
+- ARGO-3917 Handle attribute names which are not all capital letters
+- ARGO-3913 Add extra filter to mimic hard/soft state for some metrics
+- ARGO-3801 Add feature to override parameters from POEM
+- ARGO-3761 Handle filters and handlers for tenants not using the publisher
+- ARGO-3760 Treat "default" namespace differently
 * Thu May 5 2022 Katarina Zailac <kzailac@srce.hr> - 0.1.0-1%{?dist}
 - ARGO-3606 Investigate Sensu as replacement for Nagios


### PR DESCRIPTION
**Features**

- ARGO-4235 Remove regex validation of entity names
- ARGO-4228 Create tool to acknowledge alerts
- ARGO-4224 Skip configuration in case of data fetch error
- ARGO-4223 Create a tool that is going to force run check for an entity
- ARGO-4222 Create a tool that is going to display how exactly the probe is invoked
- ARGO-4091Delete all the resources in the namespace when it is no longer used
- ARGO-4215 Send entire metric output message to publisher
- ARGO-4193 Log calls to ams-metric-to-queue tool
- ARGO-4203 Send hostname_id in metric result
- ARGO-4197 Skip creation of improperly formatted entities
- ARGO-4189 Send metric output to ams
- ARGO-4139 Possibility to override default arguments
- ARGO-4137 Tool not creating "path" label for entity
- ARGO-4092 Add topology filtering
- ARGO-4090 The tool not creating labels for agent
- ARGO-4098 Bug with metric parameter overrides
- ARGO-4079 The tool not reporting missing metric configuration
- ARGO-4047 Create tool for ad hoc check execution request
- ARGO-4002 Remove hard-coded default ports
- ARGO-4003 Handle hostnames in tags
- ARGO-3999 Remove hard-coded list of secrets
- ARGO-3986 Tool not handling *_URL attributes properly
- ARGO-3956 Include filter mimicking hard/soft state to non-internal checks
- ARGO-3945 Include internal checks for sensu agent
- ARGO-3944 Improve filter for internal events
- ARGO-3910 Improve logging when setting up the configuration
- ARGO-3917 Handle attribute names which are not all capital letters
- ARGO-3913 Add extra filter to mimic hard/soft state for some metrics
- ARGO-3801 Add feature to override parameters from POEM
- ARGO-3761 Handle filters and handlers for tenants not using the publisher
- ARGO-3760 Treat "default" namespace differently