### PR TITLE
ARGO-5709 Resilient scg-reload for failed tenant topology syncs in same Sensu namespace

### DIFF
--- a/exec/scg-reload.py
+++ b/exec/scg-reload.py
@@ -4,8 +4,13 @@ import json
 import sys
 
 from argo_scg.config import Config, AgentConfig
-from argo_scg.exceptions import SensuException, ConfigException, \
-    PoemException, WebApiException, GeneratorException
+from argo_scg.exceptions import (
+    SensuException,
+    ConfigException,
+    PoemException,
+    WebApiException,
+    GeneratorException,
+)
 from argo_scg.generator import ConfigurationGenerator, ConfigurationMerger
 from argo_scg.logger import get_logger
 from argo_scg.poem import Poem
@@ -17,15 +22,11 @@ CONFFILE = "/etc/argo-scg/scg.conf"
 
 
 def main():
-    parser = argparse.ArgumentParser(
-        "Sync data from POEM and Web-API with Sensu"
-    )
+    parser = argparse.ArgumentParser("Sync data from POEM and Web-API with Sensu")
     parser.add_argument(
         "-c", "--conf", dest="conf", help="configuration file", default=CONFFILE
     )
-    parser.add_argument(
-        "-t", "--tenant", dest="tenant", type=str, help="tenant name"
-    )
+    parser.add_argument("-t", "--tenant", dest="tenant", type=str, help="tenant name")
     args = parser.parse_args()
 
     logger = get_logger()
@@ -58,9 +59,7 @@ def main():
                 sys.exit(2)
 
             else:
-                namespaces = {
-                    namespace4tenant(args.tenant, namespaces): [args.tenant]
-                }
+                namespaces = {namespace4tenant(args.tenant, namespaces): [args.tenant]}
 
         sensu = Sensu(url=sensu_url, token=sensu_token, namespaces=namespaces)
 
@@ -77,90 +76,112 @@ def main():
                 tenants_metric_overrides = dict()
                 tenants_attribute_overrides = dict()
                 for tenant in tenants:
-                    if publish_bool[tenant]:
-                        namespace_publish_bool = publish_bool[tenant]
+                    try:
+                        if publish_bool[tenant]:
+                            namespace_publish_bool = publish_bool[tenant]
 
-                    if namespace_secrets:
-                        if secrets[tenant] != namespace_secrets:
-                            logger.warning(
-                                f"{namespace}: Secrets file not unique across "
-                                f"tenants"
+                        if namespace_secrets:
+                            if secrets[tenant] != namespace_secrets:
+                                logger.warning(
+                                    f"{namespace}: Secrets file not unique across "
+                                    f"tenants"
+                                )
+
+                        else:
+                            namespace_secrets = secrets[tenant]
+
+                        webapi = WebApi(
+                            url=webapi_url,
+                            token=webapi_tokens[tenant],
+                            tenant=tenant,
+                            topo_groups_filter=(
+                                topo_groups_filter[tenant]
+                                if topo_groups_filter[tenant]
+                                else None
+                            ),
+                            topo_endpoints_filter=(
+                                topo_endpoints_filter[tenant]
+                                if topo_endpoints_filter[tenant]
+                                else None
+                            ),
+                        )
+
+                        poem = Poem(
+                            url=poem_urls[tenant],
+                            token=poem_tokens[tenant],
+                            tenant=tenant,
+                        )
+
+                        if local_topology[tenant]:
+                            with open(local_topology[tenant]) as f:
+                                topology = json.load(f)
+
+                        else:
+                            topology = webapi.get_topology()
+
+                        if agents_configurations[tenant]:
+                            agent_config = AgentConfig(
+                                file=agents_configurations[tenant]
                             )
+                            custom_agent_config = agent_config.get_custom_subs()
 
-                    else:
-                        namespace_secrets = secrets[tenant]
+                        else:
+                            custom_agent_config = None
 
-                    webapi = WebApi(
-                        url=webapi_url,
-                        token=webapi_tokens[tenant],
-                        tenant=tenant,
-                        topo_groups_filter=topo_groups_filter[tenant] if
-                        topo_groups_filter[tenant] else None,
-                        topo_endpoints_filter=topo_endpoints_filter[tenant] if
-                        topo_endpoints_filter[tenant] else None
-                    )
-
-                    poem = Poem(
-                        url=poem_urls[tenant],
-                        token=poem_tokens[tenant],
-                        tenant=tenant
-                    )
-
-                    if local_topology[tenant]:
-                        with open(local_topology[tenant]) as f:
-                            topology = json.load(f)
-
-                    else:
-                        topology = webapi.get_topology()
-
-                    if agents_configurations[tenant]:
-                        agent_config = AgentConfig(
-                            file=agents_configurations[tenant]
+                        generator = ConfigurationGenerator(
+                            metrics=poem.get_metrics_configurations(),
+                            metric_profiles=webapi.get_metric_profiles(),
+                            topology=topology,
+                            profiles=metricprofiles[tenant],
+                            attributes=poem.get_metric_overrides(),
+                            secrets_file=secrets[tenant],
+                            default_ports=poem.get_default_ports(),
+                            tenant=tenant,
+                            default_agent=[
+                                item["metadata"]["name"]
+                                for item in sensu.get_agents(namespace=namespace)
+                            ],
+                            skipped_metrics=skipped_metrics[tenant],
+                            agents_config=custom_agent_config,
                         )
-                        custom_agent_config = agent_config.get_custom_subs()
 
-                    else:
-                        custom_agent_config = None
-
-                    generator = ConfigurationGenerator(
-                        metrics=poem.get_metrics_configurations(),
-                        metric_profiles=webapi.get_metric_profiles(),
-                        topology=topology,
-                        profiles=metricprofiles[tenant],
-                        attributes=poem.get_metric_overrides(),
-                        secrets_file=secrets[tenant],
-                        default_ports=poem.get_default_ports(),
-                        tenant=tenant,
-                        default_agent=[
-                            item["metadata"]["name"] for item in
-                            sensu.get_agents(namespace=namespace)
-                        ],
-                        skipped_metrics=skipped_metrics[tenant],
-                        agents_config=custom_agent_config
-                    )
-
-                    tenants_checks.update({
-                        tenant: generator.generate_checks(
-                            publish=publish_bool[tenant],
-                            namespace=namespace
+                        tenants_checks.update(
+                            {
+                                tenant: generator.generate_checks(
+                                    publish=publish_bool[tenant], namespace=namespace
+                                )
+                            }
                         )
-                    })
 
-                    tenants_entities.update({
-                        tenant: generator.generate_entities(namespace=namespace)
-                    })
+                        tenants_entities.update(
+                            {tenant: generator.generate_entities(namespace=namespace)}
+                        )
 
-                    tenants_internal_services.update({
-                        tenant: generator.generate_internal_services()
-                    })
+                        tenants_internal_services.update(
+                            {tenant: generator.generate_internal_services()}
+                        )
 
-                    tenants_metric_overrides.update({
-                        tenant: generator.get_metric_parameter_overrides()
-                    })
+                        tenants_metric_overrides.update(
+                            {tenant: generator.get_metric_parameter_overrides()}
+                        )
 
-                    tenants_attribute_overrides.update({
-                        tenant: generator.get_host_attribute_overrides()
-                    })
+                        tenants_attribute_overrides.update(
+                            {tenant: generator.get_host_attribute_overrides()}
+                        )
+                    except (
+                        WebApiException,
+                        PoemException,
+                        GeneratorException,
+                        SensuException,
+                    ):
+                        logger.warning(f"{namespace}: Skipping configuration...")
+                        continue
+
+                    except Exception as e:
+                        logger.warning(
+                            f"{namespace}: {str(e)} Skipping configuration..."
+                        )
+                        continue
 
                 if len(tenants) > 1:
                     merger = ConfigurationMerger(
@@ -168,26 +189,22 @@ def main():
                         entities=tenants_entities,
                         internal_services=tenants_internal_services,
                         metricoverrides4agents=tenants_metric_overrides,
-                        attributeoverrides4agents=tenants_attribute_overrides
+                        attributeoverrides4agents=tenants_attribute_overrides,
                     )
 
                     checks = merger.merge_checks()
                     entities = merger.merge_entities()
-                    metric_parameter_overrides = \
+                    metric_parameter_overrides = (
                         merger.merge_metric_parameter_overrides()
-                    host_attribute_overrides = \
-                        merger.merge_attribute_overrides()
+                    )
+                    host_attribute_overrides = merger.merge_attribute_overrides()
                     internal_services = merger.merge_internal_services()
 
                 else:
                     checks = tenants_checks[tenants[0]]
                     entities = tenants_entities[tenants[0]]
-                    metric_parameter_overrides = tenants_metric_overrides[
-                        tenants[0]
-                    ]
-                    host_attribute_overrides = tenants_attribute_overrides[
-                        tenants[0]
-                    ]
+                    metric_parameter_overrides = tenants_metric_overrides[tenants[0]]
+                    host_attribute_overrides = tenants_attribute_overrides[tenants[0]]
                     internal_services = tenants_internal_services[tenants[0]]
 
                 sensu.add_daily_filter(namespace=namespace)
@@ -206,15 +223,13 @@ def main():
                 sensu.add_memory_check(namespace=namespace)
 
                 if namespace != "default":
-                    sensu.handle_proxy_entities(
-                        entities=entities, namespace=namespace
-                    )
+                    sensu.handle_proxy_entities(entities=entities, namespace=namespace)
 
                 sensu.handle_agents(
                     metric_parameters_overrides=metric_parameter_overrides,
                     host_attributes_overrides=host_attribute_overrides,
                     services=internal_services,
-                    namespace=namespace
+                    namespace=namespace,
                 )
 
                 logger.info(f"{namespace}: All synced!")
@@ -224,17 +239,12 @@ def main():
                 logger.warning(f"{namespace}: Skipping configuration...")
                 continue
 
-            except (
-                    WebApiException, PoemException, GeneratorException,
-                    SensuException
-            ):
+            except (WebApiException, PoemException, GeneratorException, SensuException):
                 logger.warning(f"{namespace}: Skipping configuration...")
                 continue
 
             except Exception as e:
-                logger.warning(
-                    f"{namespace}: {str(e)} Skipping configuration..."
-                )
+                logger.warning(f"{namespace}: {str(e)} Skipping configuration...")
                 continue
 
         logger.info("Done")

--- a/tests/test_sensu.py
+++ b/tests/test_sensu.py
@@ -3,6 +3,7 @@ import json
 import logging
 import subprocess
 import unittest
+import datetime
 from unittest.mock import patch, call
 
 from argo_scg.exceptions import SensuException, SCGWarnException
@@ -14,14 +15,12 @@ mock_entities = [
     {
         "entity_class": "proxy",
         "system": {
-            "network": {
-                "interfaces": None
-            },
+            "network": {"interfaces": None},
             "libc_type": "",
             "vm_system": "",
             "vm_role": "",
             "cloud_provider": "",
-            "processes": None
+            "processes": None,
         },
         "subscriptions": None,
         "last_seen": 0,
@@ -34,22 +33,20 @@ mock_entities = [
                 "sensu.io/managed_by": "sensuctl",
                 "hostname": "argo-devel.ni4os.eu",
                 "argo_webui": "argo.webui",
-                "tenants": "TENANT1"
-            }
+                "tenants": "TENANT1",
+            },
         },
-        "sensu_agent_version": ""
+        "sensu_agent_version": "",
     },
     {
         "entity_class": "proxy",
         "system": {
-            "network": {
-                "interfaces": None
-            },
+            "network": {"interfaces": None},
             "libc_type": "",
             "vm_system": "",
             "vm_role": "",
             "cloud_provider": "",
-            "processes": None
+            "processes": None,
         },
         "subscriptions": None,
         "last_seen": 0,
@@ -62,22 +59,20 @@ mock_entities = [
                 "sensu.io/managed_by": "sensuctl",
                 "hostname": "argo.ni4os.eu",
                 "generic_http_connect": "generic.http.connect",
-                "tenants": "TENANT1"
-            }
+                "tenants": "TENANT1",
+            },
         },
-        "sensu_agent_version": ""
+        "sensu_agent_version": "",
     },
     {
         "entity_class": "proxy",
         "system": {
-            "network": {
-                "interfaces": None
-            },
+            "network": {"interfaces": None},
             "libc_type": "",
             "vm_system": "",
             "vm_role": "",
             "cloud_provider": "",
-            "processes": None
+            "processes": None,
         },
         "subscriptions": None,
         "last_seen": 0,
@@ -90,10 +85,10 @@ mock_entities = [
                 "hostname": "gocdb.ni4os.eu",
                 "sensu.io/managed_by": "sensuctl",
                 "eu_ni4os_ops_gocdb": "eu.ni4os.ops.gocdb",
-                "tenants": "TENANT1"
-            }
+                "tenants": "TENANT1",
+            },
         },
-        "sensu_agent_version": ""
+        "sensu_agent_version": "",
     },
     {
         "entity_class": "agent",
@@ -105,15 +100,8 @@ mock_entities = [
             "platform_version": "7.8.2003",
             "network": {
                 "interfaces": [
-                    {
-                        "name": "lo",
-                        "addresses": ["xxx.x.x.x/x"]
-                    },
-                    {
-                        "name": "eth0",
-                        "mac": "xx:xx:xx:xx:xx:xx",
-                        "addresses": ["xx.x.xxx.xxx/xx"]
-                    }
+                    {"name": "lo", "addresses": ["xxx.x.x.x/x"]},
+                    {"name": "eth0", "mac": "xx:xx:xx:xx:xx:xx", "addresses": ["xx.x.xxx.xxx/xx"]},
                 ]
             },
             "arch": "amd64",
@@ -121,12 +109,9 @@ mock_entities = [
             "vm_system": "",
             "vm_role": "guest",
             "cloud_provider": "",
-            "processes": None
+            "processes": None,
         },
-        "subscriptions": [
-            "entity:sensu-agent1",
-            "internals"
-        ],
+        "subscriptions": ["entity:sensu-agent1", "internals"],
         "last_seen": 1645005291,
         "deregister": False,
         "deregistration": {},
@@ -140,17 +125,14 @@ mock_entities = [
             "access_key",
             "secret_key",
             "private_key",
-            "secret"
+            "secret",
         ],
         "metadata": {
             "name": "sensu-agent1",
             "namespace": "tenant1",
-            "labels": {
-                "hostname": "sensu-agent1",
-                "services": "internals"
-            }
+            "labels": {"hostname": "sensu-agent1", "services": "internals"},
         },
-        "sensu_agent_version": "6.6.3"
+        "sensu_agent_version": "6.6.3",
     },
     {
         "entity_class": "agent",
@@ -162,15 +144,8 @@ mock_entities = [
             "platform_version": "7.9.2009",
             "network": {
                 "interfaces": [
-                    {
-                        "name": "lo",
-                        "addresses": ["xxx.x.x.x/x"]
-                    },
-                    {
-                        "name": "eth0",
-                        "mac": "xx:xx:xx:xx:xx:xx",
-                        "addresses": ["xx.x.xxx.xxx/xx"]
-                    }
+                    {"name": "lo", "addresses": ["xxx.x.x.x/x"]},
+                    {"name": "eth0", "mac": "xx:xx:xx:xx:xx:xx", "addresses": ["xx.x.xxx.xxx/xx"]},
                 ]
             },
             "arch": "amd64",
@@ -178,12 +153,9 @@ mock_entities = [
             "vm_system": "",
             "vm_role": "guest",
             "cloud_provider": "",
-            "processes": None
+            "processes": None,
         },
-        "subscriptions": [
-            "entity:sensu-agent2",
-            "internals"
-        ],
+        "subscriptions": ["entity:sensu-agent2", "internals"],
         "last_seen": 1645005284,
         "deregister": False,
         "deregistration": {},
@@ -197,32 +169,26 @@ mock_entities = [
             "access_key",
             "secret_key",
             "private_key",
-            "secret"
+            "secret",
         ],
-        "metadata": {
-            "name": "sensu-agent2",
-            "services": "internals",
-            "namespace": "tenant1"
-        },
-        "sensu_agent_version": "6.6.5"
-    }
+        "metadata": {"name": "sensu-agent2", "services": "internals", "namespace": "tenant1"},
+        "sensu_agent_version": "6.6.5",
+    },
 ]
 
 mock_checks = [
     {
         "command": "/usr/lib64/nagios/plugins/check_http "
-                   "-H {{ .labels.hostname }} -t 30 -r argo.eu "
-                   "-u /ni4os/report-ar/Critical/NGI?accept=csv --ssl  "
-                   "--onredirect follow",
+        "-H {{ .labels.hostname }} -t 30 -r argo.eu "
+        "-u /ni4os/report-ar/Critical/NGI?accept=csv --ssl  "
+        "--onredirect follow",
         "handlers": ["publisher-handler"],
         "high_flap_threshold": 0,
         "interval": 300,
         "low_flap_threshold": 0,
         "publish": True,
         "runtime_assets": None,
-        "subscriptions": [
-            "entity:sensu-agent1"
-        ],
+        "subscriptions": ["entity:sensu-agent1"],
         "proxy_entity_name": "",
         "check_hooks": None,
         "stdin": False,
@@ -232,11 +198,10 @@ mock_checks = [
         "proxy_requests": {
             "entity_attributes": [
                 "entity.entity_class == 'proxy'",
-                "entity.labels.generic_http_ar_argoui_ni4os == "
-                "'generic.http.ar-argoui-ni4os'"
+                "entity.labels.generic_http_ar_argoui_ni4os == 'generic.http.ar-argoui-ni4os'",
             ],
             "splay": False,
-            "splay_coverage": 0
+            "splay_coverage": 0,
         },
         "round_robin": False,
         "output_metric_format": "",
@@ -246,30 +211,24 @@ mock_checks = [
             "name": "generic.http.ar-argoui-ni4os",
             "namespace": "tenant1",
             "created_by": "root",
-            "annotations": {
-                "attempts": "2"
-            },
-            "labels": {
-                "tenants": "TENANT1"
-            }
+            "annotations": {"attempts": "2"},
+            "labels": {"tenants": "TENANT1"},
         },
         "secrets": None,
-        "pipelines": []
+        "pipelines": [],
     },
     {
         "command": "/usr/lib64/nagios/plugins/check_http "
-                   "-H {{ .labels.hostname }} -t 30 -r SRCE "
-                   "-u /ni4os/report-status/Critical/SITES?accept=csv --ssl  "
-                   "--onredirect follow",
+        "-H {{ .labels.hostname }} -t 30 -r SRCE "
+        "-u /ni4os/report-status/Critical/SITES?accept=csv --ssl  "
+        "--onredirect follow",
         "handlers": ["publisher-handler"],
         "high_flap_threshold": 0,
         "interval": 300,
         "low_flap_threshold": 0,
         "publish": True,
         "runtime_assets": None,
-        "subscriptions": [
-            "entity:sensu-agent1"
-        ],
+        "subscriptions": ["entity:sensu-agent1"],
         "proxy_entity_name": "",
         "check_hooks": None,
         "stdin": False,
@@ -280,10 +239,10 @@ mock_checks = [
             "entity_attributes": [
                 "entity.entity_class == 'proxy'",
                 "entity.labels.generic_http_status_argoui_ni4os == "
-                "'generic.http.status-argoui-ni4os'"
+                "'generic.http.status-argoui-ni4os'",
             ],
             "splay": False,
-            "splay_coverage": 0
+            "splay_coverage": 0,
         },
         "round_robin": False,
         "output_metric_format": "",
@@ -293,28 +252,21 @@ mock_checks = [
             "name": "generic.http.status-argoui-ni4os",
             "namespace": "tenant1",
             "created_by": "root",
-            "annotations": {
-                "attempts": "2"
-            },
-            "labels": {
-                "tenants": "TENANT1"
-            }
+            "annotations": {"attempts": "2"},
+            "labels": {"tenants": "TENANT1"},
         },
         "secrets": None,
-        "pipelines": []
+        "pipelines": [],
     },
     {
-        "command": "/usr/lib64/nagios/plugins/check_tcp "
-                   "-H {{ .labels.hostname }} -t 120 -p 443",
+        "command": "/usr/lib64/nagios/plugins/check_tcp -H {{ .labels.hostname }} -t 120 -p 443",
         "handlers": [],
         "high_flap_threshold": 0,
         "interval": 300,
         "low_flap_threshold": 0,
         "publish": True,
         "runtime_assets": None,
-        "subscriptions": [
-            "entity:sensu-agent1"
-        ],
+        "subscriptions": ["entity:sensu-agent1"],
         "proxy_entity_name": "",
         "check_hooks": None,
         "stdin": False,
@@ -324,10 +276,10 @@ mock_checks = [
         "proxy_requests": {
             "entity_attributes": [
                 "entity.entity_class == 'proxy'",
-                "entity.labels.generic_tcp_connect == 'generic.tcp.connect'"
+                "entity.labels.generic_tcp_connect == 'generic.tcp.connect'",
             ],
             "splay": False,
-            "splay_coverage": 0
+            "splay_coverage": 0,
         },
         "round_robin": True,
         "output_metric_format": "",
@@ -337,15 +289,11 @@ mock_checks = [
             "name": "generic.tcp.connect",
             "namespace": "tenant1",
             "created_by": "root",
-            "annotations": {
-                "attempts": "3"
-            },
-            "labels": {
-                "tenants": "TENANT1"
-            }
+            "annotations": {"attempts": "3"},
+            "labels": {"tenants": "TENANT1"},
         },
         "secrets": None,
-        "pipelines": []
+        "pipelines": [],
     },
     {
         "command": "check-cpu-usage -w 85 -c 90",
@@ -354,13 +302,8 @@ mock_checks = [
         "interval": 300,
         "low_flap_threshold": 0,
         "publish": True,
-        "runtime_assets": [
-            "check-cpu-usage"
-        ],
-        "subscriptions": [
-            "entity:sensu-agent1",
-            "entity:sensu-agent2"
-        ],
+        "runtime_assets": ["check-cpu-usage"],
+        "subscriptions": ["entity:sensu-agent1", "entity:sensu-agent2"],
         "proxy_entity_name": "",
         "check_hooks": None,
         "stdin": False,
@@ -374,19 +317,11 @@ mock_checks = [
         "metadata": {
             "name": "sensu.cpu.usage",
             "namespace": "tenant1",
-            "annotations": {
-                "attempts": "3"
-            },
-            "created_by": "admin"
+            "annotations": {"attempts": "3"},
+            "created_by": "admin",
         },
         "secrets": None,
-        "pipelines": [
-            {
-                "name": "reduce_alerts",
-                "type": "Pipeline",
-                "api_version": "core/v2"
-            }
-        ]
+        "pipelines": [{"name": "reduce_alerts", "type": "Pipeline", "api_version": "core/v2"}],
     },
     {
         "command": "check-memory-usage -w 85 -c 90",
@@ -395,12 +330,8 @@ mock_checks = [
         "interval": 300,
         "low_flap_threshold": 0,
         "publish": True,
-        "runtime_assets": [
-            "check-memory-usage"
-        ],
-        "subscriptions": [
-            "entity:sensu-agent1"
-        ],
+        "runtime_assets": ["check-memory-usage"],
+        "subscriptions": ["entity:sensu-agent1"],
         "proxy_entity_name": "",
         "check_hooks": None,
         "stdin": False,
@@ -414,20 +345,12 @@ mock_checks = [
         "metadata": {
             "name": "sensu.memory.usage",
             "namespace": "tenant1",
-            "annotations": {
-                "attempts": "3"
-            },
-            "created_by": "admin"
+            "annotations": {"attempts": "3"},
+            "created_by": "admin",
         },
         "secrets": None,
-        "pipelines": [
-            {
-                "name": "reduce_alerts",
-                "type": "Pipeline",
-                "api_version": "core/v2"
-            }
-        ]
-    }
+        "pipelines": [{"name": "reduce_alerts", "type": "Pipeline", "api_version": "core/v2"}],
+    },
 ]
 
 mock_events = [
@@ -439,14 +362,12 @@ mock_events = [
         "entity": {
             "entity_class": "proxy",
             "system": {
-                "network": {
-                    "interfaces": None
-                },
+                "network": {"interfaces": None},
                 "libc_type": "",
                 "vm_system": "",
                 "vm_role": "",
                 "cloud_provider": "",
-                "processes": None
+                "processes": None,
             },
             "subscriptions": None,
             "last_seen": 0,
@@ -456,28 +377,25 @@ mock_events = [
                 "name": "argo.ni4os.eu",
                 "namespace": "tenant1",
                 "labels": {
-                    "generic_http_ar_argoui_ni4os":
-                        "generic.http.ar-argoui-ni4os",
+                    "generic_http_ar_argoui_ni4os": "generic.http.ar-argoui-ni4os",
                     "hostname": "argo.ni4os.eu",
-                    "tenants": "TENANT1"
-                }
+                    "tenants": "TENANT1",
+                },
             },
-            "sensu_agent_version": ""
+            "sensu_agent_version": "",
         },
         "check": {
             "command": "/usr/lib64/nagios/plugins/check_http "
-                       "-H argo.ni4os.eu -t 30 -r argo.eu "
-                       "-u /ni4os/report-ar/Critical/NGI?accept=csv "
-                       "--ssl  --onredirect follow",
+            "-H argo.ni4os.eu -t 30 -r argo.eu "
+            "-u /ni4os/report-ar/Critical/NGI?accept=csv "
+            "--ssl  --onredirect follow",
             "handlers": [],
             "high_flap_threshold": 0,
             "interval": 300,
             "low_flap_threshold": 0,
             "publish": True,
             "runtime_assets": None,
-            "subscriptions": [
-                "entity:sensu-agent1"
-            ],
+            "subscriptions": ["entity:sensu-agent1"],
             "proxy_entity_name": "argo.ni4os.eu",
             "check_hooks": None,
             "stdin": False,
@@ -487,37 +405,24 @@ mock_events = [
             "proxy_requests": {
                 "entity_attributes": [
                     "entity.entity_class == 'proxy'",
-                    "entity.labels.generic_http_ar_argoui_ni4os == "
-                    "'generic.http.ar-argoui-ni4os'"
+                    "entity.labels.generic_http_ar_argoui_ni4os == 'generic.http.ar-argoui-ni4os'",
                 ],
                 "splay": False,
-                "splay_coverage": 0
+                "splay_coverage": 0,
             },
             "round_robin": False,
             "duration": 0.393113841,
             "executed": 1645518791,
             "history": [
-                {
-                    "status": 0,
-                    "executed": 1645515791
-                },
-                {
-                    "status": 0,
-                    "executed": 1645516091
-                },
-                {
-                    "status": 0,
-                    "executed": 1645516091
-                },
-                {
-                    "status": 0,
-                    "executed": 1645516391
-                }
+                {"status": 0, "executed": 1645515791},
+                {"status": 0, "executed": 1645516091},
+                {"status": 0, "executed": 1645516091},
+                {"status": 0, "executed": 1645516391},
             ],
             "issued": 1645518791,
             "output": "HTTP OK: HTTP/1.1 200 OK - 28895 bytes in 0.379 "
-                      "second response time |time=0.379190s;;;0.000000 "
-                      "size=28895B;;;0\n",
+            "second response time |time=0.379190s;;;0.000000 "
+            "size=28895B;;;0\n",
             "state": "passing",
             "status": 0,
             "total_state_change": 0,
@@ -530,19 +435,15 @@ mock_events = [
             "metadata": {
                 "name": "generic.http.ar-argoui-ni4os",
                 "namespace": "tenant1",
-                "labels": {
-                    "tenants": "TENANT1"
-                }
+                "labels": {"tenants": "TENANT1"},
             },
             "secrets": None,
             "is_silenced": False,
             "scheduler": "",
             "processed_by": "agent2",
-            "pipelines": []
+            "pipelines": [],
         },
-        "metadata": {
-            "namespace": "tenant1"
-        }
+        "metadata": {"namespace": "tenant1"},
     },
     {
         "pipelines": None,
@@ -550,18 +451,14 @@ mock_events = [
         "entity": {
             "entity_class": "proxy",
             "system": {
-                "network": {
-                    "interfaces": None
-                },
+                "network": {"interfaces": None},
                 "libc_type": "",
                 "vm_system": "",
                 "vm_role": "",
                 "cloud_provider": "",
-                "processes": None
+                "processes": None,
             },
-            "subscriptions": [
-                "entity:sensu-agent1"
-            ],
+            "subscriptions": ["entity:sensu-agent1"],
             "last_seen": 0,
             "deregister": False,
             "deregistration": {},
@@ -571,23 +468,20 @@ mock_events = [
                 "labels": {
                     "generic_tcp_connect": "generic.tcp.connect",
                     "hostname": "gocdb.ni4os.eu",
-                    "tenants": "TENANT1"
-                }
+                    "tenants": "TENANT1",
+                },
             },
-            "sensu_agent_version": ""
+            "sensu_agent_version": "",
         },
         "check": {
-            "command": "/usr/lib64/nagios/plugins/check_tcp "
-                       "-H gocdb.ni4os.eu -t 120 -p 443",
+            "command": "/usr/lib64/nagios/plugins/check_tcp -H gocdb.ni4os.eu -t 120 -p 443",
             "handlers": [],
             "high_flap_threshold": 0,
             "interval": 300,
             "low_flap_threshold": 0,
             "publish": True,
             "runtime_assets": None,
-            "subscriptions": [
-                "entity:sensu-agent1"
-            ],
+            "subscriptions": ["entity:sensu-agent1"],
             "proxy_entity_name": "gocdb.ni4os.eu",
             "check_hooks": None,
             "stdin": False,
@@ -597,11 +491,10 @@ mock_events = [
             "proxy_requests": {
                 "entity_attributes": [
                     "entity.entity_class == 'proxy'",
-                    "entity.labels.generic_tcp_connect == "
-                    "'generic.tcp.connect'"
+                    "entity.labels.generic_tcp_connect == 'generic.tcp.connect'",
                 ],
                 "splay": False,
-                "splay_coverage": 0
+                "splay_coverage": 0,
             },
             "round_robin": False,
             "duration": 0.059516622,
@@ -609,8 +502,8 @@ mock_events = [
             "history": [],
             "issued": 1645518534,
             "output": "TCP OK - 0.045 second response time on "
-                      "gocdb.ni4os.eu port 443|time=0.044729s;;;"
-                      "0.000000;120.000000\n",
+            "gocdb.ni4os.eu port 443|time=0.044729s;;;"
+            "0.000000;120.000000\n",
             "state": "passing",
             "status": 0,
             "total_state_change": 0,
@@ -623,21 +516,17 @@ mock_events = [
             "metadata": {
                 "name": "generic.tcp.connect",
                 "namespace": "tenant1",
-                "labels": {
-                    "tenants": "TENANT1"
-                }
+                "labels": {"tenants": "TENANT1"},
             },
             "secrets": None,
             "is_silenced": False,
             "scheduler": "",
             "processed_by": "agent2",
-            "pipelines": []
+            "pipelines": [],
         },
-        "metadata": {
-            "namespace": "tenant1"
-        },
+        "metadata": {"namespace": "tenant1"},
         "id": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
-        "sequence": 1531
+        "sequence": 1531,
     },
     {
         "sequence": "xxxx",
@@ -646,18 +535,14 @@ mock_events = [
         "entity": {
             "entity_class": "proxy",
             "system": {
-                "network": {
-                    "interfaces": None
-                },
+                "network": {"interfaces": None},
                 "libc_type": "",
                 "vm_system": "",
                 "vm_role": "",
                 "cloud_provider": "",
-                "processes": None
+                "processes": None,
             },
-            "subscriptions": [
-                "entity:sensu-agent1"
-            ],
+            "subscriptions": ["entity:sensu-agent1"],
             "last_seen": 0,
             "deregister": False,
             "deregistration": {},
@@ -666,29 +551,25 @@ mock_events = [
                 "namespace": "tenant1",
                 "labels": {
                     "hostname": "argo.ni4os.eu",
-                    "generic_http_ar_argoui_ni4os":
-                        "generic.http.ar-argoui-ni4os",
-                    "generic_http_status_argoui_ni4os":
-                        "generic.http.status-argoui-ni4os",
-                    "tenants": "TENANT1"
-                }
+                    "generic_http_ar_argoui_ni4os": "generic.http.ar-argoui-ni4os",
+                    "generic_http_status_argoui_ni4os": "generic.http.status-argoui-ni4os",
+                    "tenants": "TENANT1",
+                },
             },
-            "sensu_agent_version": ""
+            "sensu_agent_version": "",
         },
         "check": {
             "command": "/usr/lib64/nagios/plugins/check_http "
-                       "-H argo.ni4os.eu -t 30 -r SRCE "
-                       "-u /ni4os/report-status/Critical/SITES?accept=csv "
-                       "--ssl  --onredirect follow",
+            "-H argo.ni4os.eu -t 30 -r SRCE "
+            "-u /ni4os/report-status/Critical/SITES?accept=csv "
+            "--ssl  --onredirect follow",
             "handlers": [],
             "high_flap_threshold": 0,
             "interval": 300,
             "low_flap_threshold": 0,
             "publish": True,
             "runtime_assets": None,
-            "subscriptions": [
-                "entity:sensu-agent1"
-            ],
+            "subscriptions": ["entity:sensu-agent1"],
             "proxy_entity_name": "argo.ni4os.eu",
             "check_hooks": None,
             "stdin": False,
@@ -699,10 +580,10 @@ mock_events = [
                 "entity_attributes": [
                     "entity.entity_class == 'proxy'",
                     "entity.labels.generic_http_status_argoui_ni4os == "
-                    "'generic.http.status-argoui-ni4os'"
+                    "'generic.http.status-argoui-ni4os'",
                 ],
                 "splay": False,
-                "splay_coverage": 0
+                "splay_coverage": 0,
             },
             "round_robin": False,
             "duration": 0.799173492,
@@ -710,8 +591,8 @@ mock_events = [
             "history": [],
             "issued": 1645521135,
             "output": "HTTP OK: HTTP/1.1 200 OK - 74359 bytes in 0.795 second "
-                      "response time |time=0.795143s;;;0.000000 size=74359B;;;"
-                      "0\n",
+            "response time |time=0.795143s;;;0.000000 size=74359B;;;"
+            "0\n",
             "state": "passing",
             "status": 0,
             "total_state_change": 0,
@@ -724,133 +605,99 @@ mock_events = [
             "metadata": {
                 "name": "generic.http.status-argoui-ni4os",
                 "namespace": "tenant1",
-                "labels": {
-                    "tenants": "TENANT1"
-                }
+                "labels": {"tenants": "TENANT1"},
             },
             "secrets": None,
             "is_silenced": False,
             "scheduler": "",
             "processed_by": "agent2",
-            "pipelines": []
+            "pipelines": [],
         },
-        "metadata": {
-            "namespace": "tenant1"
-        },
-        "id": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
-    }
+        "metadata": {"namespace": "tenant1"},
+        "id": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
+    },
 ]
 
 mock_metrics = [
     {
         "generic.http.ar-argoui-ni4os": {
-            "tags": [
-                "argo.webui",
-                "harmonized"
-            ],
+            "tags": ["argo.webui", "harmonized"],
             "probe": "check_http",
             "config": {
                 "timeout": "30",
                 "retryInterval": "3",
                 "path": "/usr/lib64/nagios/plugins",
                 "maxCheckAttempts": "3",
-                "interval": "5"
+                "interval": "5",
             },
-            "flags": {
-                "OBSESS": "1",
-                "PNP": "1"
-            },
+            "flags": {"OBSESS": "1", "PNP": "1"},
             "dependency": {},
             "attribute": {},
             "parameter": {
                 "-r": "argo.eu",
                 "-u": "/ni4os/report-ar/Critical/NGI?accept=csv",
                 "--ssl": "0",
-                "--onredirect": "follow"
+                "--onredirect": "follow",
             },
             "file_parameter": {},
             "file_attribute": {},
             "parent": "",
-            "docurl": "http://nagios-plugins.org/doc/man/check_http."
-                      "html"
+            "docurl": "http://nagios-plugins.org/doc/man/check_http.html",
         }
     },
     {
         "generic.tcp.connect": {
-            "tags": [
-                "harmonized"
-            ],
+            "tags": ["harmonized"],
             "probe": "check_tcp",
             "config": {
                 "interval": "5",
                 "maxCheckAttempts": "3",
                 "path": "/usr/lib64/nagios/plugins/",
                 "retryInterval": "3",
-                "timeout": "120"
+                "timeout": "120",
             },
-            "flags": {
-                "OBSESS": "1",
-                "PNP": "1"
-            },
+            "flags": {"OBSESS": "1", "PNP": "1"},
             "dependency": {},
             "attribute": {},
-            "parameter": {
-                "-p": "443"
-            },
+            "parameter": {"-p": "443"},
             "file_parameter": {},
             "file_attribute": {},
             "parent": "",
-            "docurl": "http://nagios-plugins.org/doc/man/check_tcp.html"
+            "docurl": "http://nagios-plugins.org/doc/man/check_tcp.html",
         }
     },
     {
         "generic.certificate.validity": {
-            "tags": [
-                "harmonized"
-            ],
+            "tags": ["harmonized"],
             "probe": "check_ssl_cert",
             "config": {
                 "timeout": "60",
                 "retryInterval": "30",
                 "path": "/usr/lib64/nagios/plugins",
                 "maxCheckAttempts": "2",
-                "interval": "240"
+                "interval": "240",
             },
-            "flags": {
-                "OBSESS": "1"
-            },
+            "flags": {"OBSESS": "1"},
             "dependency": {},
-            "attribute": {
-                "NAGIOS_HOST_CERT": "-C",
-                "NAGIOS_HOST_KEY": "-K"
-            },
+            "attribute": {"NAGIOS_HOST_CERT": "-C", "NAGIOS_HOST_KEY": "-K"},
             "parameter": {
                 "-w": "30 -c 0 -N --altnames",
                 "--rootcert-dir": "/etc/grid-security/certificates",
-                "--rootcert-file": "/etc/pki/tls/certs/ca-bundle.crt"
+                "--rootcert-file": "/etc/pki/tls/certs/ca-bundle.crt",
             },
             "file_parameter": {},
             "file_attribute": {},
             "parent": "",
-            "docurl": "https://github.com/matteocorti/check_ssl_cert/"
-                      "blob/master/README.md"
+            "docurl": "https://github.com/matteocorti/check_ssl_cert/blob/master/README.md",
         }
-    }
+    },
 ]
 
 mock_namespaces = [
-    {
-        "name": "default"
-    },
-    {
-        "name": "tenant1"
-    },
-    {
-        "name": "tenant2"
-    },
-    {
-        "name": "sensu-system"
-    }
+    {"name": "default"},
+    {"name": "tenant1"},
+    {"name": "tenant2"},
+    {"name": "sensu-system"},
 ]
 
 mock_metrics_hardcoded_attributes = [
@@ -863,25 +710,19 @@ mock_metrics_hardcoded_attributes = [
                 "maxCheckAttempts": "3",
                 "path": "/usr/libexec/argo-monitoring/probes/activemq",
                 "retryInterval": "3",
-                "timeout": "30"
+                "timeout": "30",
             },
-            "flags": {
-                "NOHOSTNAME": "1",
-                "OBSESS": "1"
-            },
+            "flags": {"NOHOSTNAME": "1", "OBSESS": "1"},
             "dependency": {},
-            "attribute": {
-                "KEYSTORE": "-K",
-                "TRUSTSTORE": "-T"
-            },
+            "attribute": {"KEYSTORE": "-K", "TRUSTSTORE": "-T"},
             "parameter": {
                 "--keystoretype": "jks",
-                "-s": "monitor.test.$_SERVICESERVER$.$HOSTALIAS$.openwiressl"
+                "-s": "monitor.test.$_SERVICESERVER$.$HOSTALIAS$.openwiressl",
             },
             "file_parameter": {},
             "file_attribute": {},
             "parent": "",
-            "docurl": "https://wiki.egi.eu/wiki/OPS-MONITOR_profile_SAM_tests"
+            "docurl": "https://wiki.egi.eu/wiki/OPS-MONITOR_profile_SAM_tests",
         }
     },
     {
@@ -893,48 +734,35 @@ mock_metrics_hardcoded_attributes = [
                 "maxCheckAttempts": "3",
                 "path": "/usr/libexec/argo-monitoring/probes/midmon",
                 "retryInterval": "15",
-                "timeout": "30"
+                "timeout": "30",
             },
-            "flags": {
-                "NOHOSTNAME": "1",
-                "OBSESS": "1",
-                "PNP": "1"
-            },
+            "flags": {"NOHOSTNAME": "1", "OBSESS": "1", "PNP": "1"},
             "dependency": {},
-            "attribute": {
-                "BDII_PORT": "-p",
-                "TOP_BDII": "-H"
-            },
+            "attribute": {"BDII_PORT": "-p", "TOP_BDII": "-H"},
             "parameter": {
                 "-b": "Mds-Vo-Name=local,O=grid",
                 "-c": "4:4",
-                "-f": "\"(GlueServiceEndpoint=*$HOSTALIAS$*)\""
+                "-f": '"(GlueServiceEndpoint=*$HOSTALIAS$*)"',
             },
             "file_parameter": {},
             "file_attribute": {},
             "parent": "",
-            "docurl": "https://wiki.egi.eu/wiki/MW_Nagios_tests"
+            "docurl": "https://wiki.egi.eu/wiki/MW_Nagios_tests",
         }
-    }
+    },
 ]
 
 mock_metrics_file_defined_attributes = [
     {
         "eudat.b2access.unity.login-local": {
-            "tags": [
-                "aai",
-                "auth",
-                "harmonized",
-                "login",
-                "sso"
-            ],
+            "tags": ["aai", "auth", "harmonized", "login", "sso"],
             "probe": "check_b2access_simple.py",
             "config": {
                 "interval": "15",
                 "maxCheckAttempts": "3",
                 "path": "/usr/libexec/argo-monitoring/probes/eudat-b2access/",
                 "retryInterval": "3",
-                "timeout": "120"
+                "timeout": "120",
             },
             "flags": {
                 "OBSESS": "1",
@@ -944,16 +772,13 @@ mock_metrics_file_defined_attributes = [
             "dependency": {},
             "attribute": {
                 "NAGIOS_B2ACCESS_LOGIN": "--username",
-                "NAGIOS_B2ACCESS_PASSWORD": "--password"
+                "NAGIOS_B2ACCESS_PASSWORD": "--password",
             },
-            "parameter": {
-                "--url": "https://b2access.fz-juelich.de:8443"
-            },
+            "parameter": {"--url": "https://b2access.fz-juelich.de:8443"},
             "file_parameter": {},
             "file_attribute": {},
             "parent": "",
-            "docurl": "https://github.com/EUDAT-B2ACCESS/b2access-probe/"
-                      "blob/master/README.md"
+            "docurl": "https://github.com/EUDAT-B2ACCESS/b2access-probe/blob/master/README.md",
         }
     },
     {
@@ -965,27 +790,21 @@ mock_metrics_file_defined_attributes = [
                 "maxCheckAttempts": "3",
                 "path": "/usr/libexec/grid-monitoring/probes",
                 "retryInterval": "10",
-                "timeout": "600"
+                "timeout": "600",
             },
-            "flags": {
-                "NRPE": "1",
-                "OBSESS": "1"
-            },
+            "flags": {"NRPE": "1", "OBSESS": "1"},
             "dependency": {
                 "hr.srce.GridProxy-Valid": "1",
-                "hr.srce.QCG-Computing-CertLifetime": "1"
+                "hr.srce.QCG-Computing-CertLifetime": "1",
             },
-            "attribute": {
-                "QCG-COMPUTING_PORT": "-p",
-                "X509_USER_PROXY": "-x"
-            },
+            "attribute": {"QCG-COMPUTING_PORT": "-p", "X509_USER_PROXY": "-x"},
             "parameter": {},
             "file_parameter": {},
             "file_attribute": {},
             "parent": "",
-            "docurl": "http://www.qoscosgrid.org/trac/qcg-computing/wiki"
+            "docurl": "http://www.qoscosgrid.org/trac/qcg-computing/wiki",
         }
-    }
+    },
 ]
 
 mock_handlers1 = [
@@ -993,21 +812,19 @@ mock_handlers1 = [
         "metadata": {
             "name": "simple_handler",
             "namespace": "tenant1",
-            "labels": {
-                "sensu.io/managed_by": "sensuctl"
-            },
-            "created_by": "root"
+            "labels": {"sensu.io/managed_by": "sensuctl"},
+            "created_by": "root",
         },
         "type": "pipe",
         "command": "jq '{header: {hostname: .entity.labels.hostname, "
-                   "metric: .check.metadata.name, status: .check.status}, "
-                   "body: .check.output}' \u003e\u003e /tmp/events.json",
+        "metric: .check.metadata.name, status: .check.status}, "
+        "body: .check.output}' \u003e\u003e /tmp/events.json",
         "timeout": 0,
         "handlers": None,
         "filters": None,
         "env_vars": None,
         "runtime_assets": None,
-        "secrets": None
+        "secrets": None,
     }
 ]
 
@@ -1016,27 +833,22 @@ mock_handlers2 = [
         "metadata": {
             "name": "simple_handler",
             "namespace": "tenant1",
-            "labels": {
-                "sensu.io/managed_by": "sensuctl"
-            },
-            "created_by": "root"
+            "labels": {"sensu.io/managed_by": "sensuctl"},
+            "created_by": "root",
         },
         "type": "pipe",
         "command": "jq '{header: {hostname: .entity.labels.hostname, "
-                   "metric: .check.metadata.name, status: .check.status}, "
-                   "body: .check.output}' \u003e\u003e /tmp/events.json",
+        "metric: .check.metadata.name, status: .check.status}, "
+        "body: .check.output}' \u003e\u003e /tmp/events.json",
         "timeout": 0,
         "handlers": None,
         "filters": None,
         "env_vars": None,
         "runtime_assets": None,
-        "secrets": None
+        "secrets": None,
     },
     {
-        "metadata": {
-            "name": "publisher-handler",
-            "namespace": "tenant1"
-        },
+        "metadata": {"name": "publisher-handler", "namespace": "tenant1"},
         "type": "pipe",
         "command": "/bin/sensu2publisher.py",
         "timeout": 0,
@@ -1044,25 +856,21 @@ mock_handlers2 = [
         "filters": None,
         "env_vars": None,
         "runtime_assets": None,
-        "secrets": None
+        "secrets": None,
     },
     {
-        "metadata": {
-            "name": "slack",
-            "namespace": "tenant1",
-            "created_by": "root"
-        },
+        "metadata": {"name": "slack", "namespace": "tenant1", "created_by": "root"},
         "type": "pipe",
         "command": "source /etc/sensu/secrets ; "
-                   "export $(cut -d= -f1 /etc/sensu/secrets) ; "
-                   "sensu-slack-handler --channel '#monitoring'",
+        "export $(cut -d= -f1 /etc/sensu/secrets) ; "
+        "sensu-slack-handler --channel '#monitoring'",
         "timeout": 0,
         "handlers": None,
         "filters": None,
         "env_vars": [],
         "runtime_assets": ["sensu-slack-handler"],
-        "secrets": None
-    }
+        "secrets": None,
+    },
 ]
 
 mock_handlers3 = [
@@ -1070,27 +878,22 @@ mock_handlers3 = [
         "metadata": {
             "name": "simple_handler",
             "namespace": "tenant1",
-            "labels": {
-                "sensu.io/managed_by": "sensuctl"
-            },
-            "created_by": "root"
+            "labels": {"sensu.io/managed_by": "sensuctl"},
+            "created_by": "root",
         },
         "type": "pipe",
         "command": "jq '{header: {hostname: .entity.labels.hostname, "
-                   "metric: .check.metadata.name, status: .check.status}, "
-                   "body: .check.output}' \u003e\u003e /tmp/events.json",
+        "metric: .check.metadata.name, status: .check.status}, "
+        "body: .check.output}' \u003e\u003e /tmp/events.json",
         "timeout": 0,
         "handlers": None,
         "filters": None,
         "env_vars": None,
         "runtime_assets": None,
-        "secrets": None
+        "secrets": None,
     },
     {
-        "metadata": {
-            "name": "publisher-handler",
-            "namespace": "tenant1"
-        },
+        "metadata": {"name": "publisher-handler", "namespace": "tenant1"},
         "type": "pipe",
         "command": "/bin/sensu2publisher.py >> /tmp/test",
         "timeout": 0,
@@ -1098,35 +901,24 @@ mock_handlers3 = [
         "filters": None,
         "env_vars": None,
         "runtime_assets": None,
-        "secrets": None
+        "secrets": None,
     },
     {
-        "metadata": {
-            "name": "slack",
-            "namespace": "tenant1",
-            "created_by": "root"
-        },
+        "metadata": {"name": "slack", "namespace": "tenant1", "created_by": "root"},
         "type": "pipe",
         "command": "sensu-slack-handler --channel '#monitoring'",
         "timeout": 0,
         "handlers": None,
         "filters": None,
-        "env_vars": [
-            'SLACK_WEBHOOK_URL=https://hooks.slack.com/services/T0000/B000/'
-            'XXXXXXXX'
-        ],
+        "env_vars": ["SLACK_WEBHOOK_URL=https://hooks.slack.com/services/T0000/B000/XXXXXXXX"],
         "runtime_assets": ["sensu-slack-handler"],
-        "secrets": None
-    }
+        "secrets": None,
+    },
 ]
 
 mock_filters1 = [
     {
-        "metadata": {
-            "name": "daily",
-            "namespace": "default",
-            "created_by": "root"
-        },
+        "metadata": {"name": "daily", "namespace": "default", "created_by": "root"},
         "action": "allow",
         "expressions": [
             "((event.check.occurrences == 1 && event.check.status == 0 && "
@@ -1138,193 +930,142 @@ mock_filters1 = [
             "event.check.occurrences % "
             "(86400 / event.check.interval) == 0"
         ],
-        "runtime_assets": None
+        "runtime_assets": None,
     },
     {
-        "metadata": {
-            "name": "hard-state",
-            "namespace": "default",
-            "created_by": "root"
-        },
+        "metadata": {"name": "hard-state", "namespace": "default", "created_by": "root"},
         "action": "allow",
         "expressions": [
             "((event.check.status == 0) || (event.check.occurrences >= "
             "Number(event.check.annotations.attempts) "
             "&& event.check.status != 0))"
         ],
-        "runtime_assets": None
-    }
+        "runtime_assets": None,
+    },
 ]
 
 mock_filters2 = [
     {
-        "metadata": {
-            "name": "daily",
-            "namespace": "default",
-            "created_by": "root"
-        },
+        "metadata": {"name": "daily", "namespace": "default", "created_by": "root"},
         "action": "allow",
         "expressions": [
             "event.check.occurrences == 1 || "
             "event.check.occurrences % (86400 / event.check.interval) == 0"
         ],
-        "runtime_assets": None
+        "runtime_assets": None,
     },
     {
-        "metadata": {
-            "name": "hard-state",
-            "namespace": "default",
-            "created_by": "root"
-        },
+        "metadata": {"name": "hard-state", "namespace": "default", "created_by": "root"},
         "action": "allow",
         "expressions": [
             "event.check.occurrences == 1 || "
             "event.check.occurrences % (86400 / event.check.interval) == 0"
         ],
-        "runtime_assets": None
-    }
+        "runtime_assets": None,
+    },
 ]
 
 mock_pipelines1 = [
     {
-        'metadata': {
-            'name': 'reduce_alerts',
-            'namespace': 'default',
-            'labels': {'sensu.io/managed_by': 'sensuctl'},
-            'created_by': 'root'
+        "metadata": {
+            "name": "reduce_alerts",
+            "namespace": "default",
+            "labels": {"sensu.io/managed_by": "sensuctl"},
+            "created_by": "root",
         },
-        'workflows': [
+        "workflows": [
             {
-                'name': 'slack_alerts',
-                'filters': [
-                    {
-                        'name': 'is_incident',
-                        'type': 'EventFilter',
-                        'api_version': 'core/v2'
-                    },
-                    {
-                        "name": "not_silenced",
-                        "type": "EventFilter",
-                        "api_version": "core/v2"
-                    },
-                    {
-                        'name': 'daily',
-                        'type': 'EventFilter',
-                        'api_version': 'core/v2'
-                    }
+                "name": "slack_alerts",
+                "filters": [
+                    {"name": "is_incident", "type": "EventFilter", "api_version": "core/v2"},
+                    {"name": "not_silenced", "type": "EventFilter", "api_version": "core/v2"},
+                    {"name": "daily", "type": "EventFilter", "api_version": "core/v2"},
                 ],
-                'handler': {
-                    'name': 'slack',
-                    'type': 'Handler',
-                    'api_version': 'core/v2'
-                }
+                "handler": {"name": "slack", "type": "Handler", "api_version": "core/v2"},
             }
-        ]
+        ],
     },
     {
-        'metadata': {
-            'name': 'hard_state',
-            'namespace': 'default',
-            'labels': {'sensu.io/managed_by': 'sensuctl'},
-            'created_by': 'root'
+        "metadata": {
+            "name": "hard_state",
+            "namespace": "default",
+            "labels": {"sensu.io/managed_by": "sensuctl"},
+            "created_by": "root",
         },
-        'workflows': [
+        "workflows": [
             {
-                'name': 'mimic_hard_state',
-                'filters': [
-                    {
-                        'name': 'hard-state',
-                        'type': 'EventFilter',
-                        'api_version': 'core/v2'
-                    }
+                "name": "mimic_hard_state",
+                "filters": [
+                    {"name": "hard-state", "type": "EventFilter", "api_version": "core/v2"}
                 ],
-                'handler': {
-                    'name': 'publisher-handler',
-                    'type': 'Handler',
-                    'api_version': 'core/v2'
-                }
+                "handler": {
+                    "name": "publisher-handler",
+                    "type": "Handler",
+                    "api_version": "core/v2",
+                },
             }
-        ]
-    }
+        ],
+    },
 ]
 
 mock_pipelines2 = [
     {
-        'metadata': {
-            'name': 'reduce_alerts',
-            'namespace': 'default',
-            'labels': {'sensu.io/managed_by': 'sensuctl'},
-            'created_by': 'root'
+        "metadata": {
+            "name": "reduce_alerts",
+            "namespace": "default",
+            "labels": {"sensu.io/managed_by": "sensuctl"},
+            "created_by": "root",
         },
-        'workflows': [
+        "workflows": [
             {
-                'name': 'slack_alerts',
-                'filters': [
-                    {
-                        'name': 'is_incident',
-                        'type': 'EventFilter',
-                        'api_version': 'core/v2'
-                    },
-                    {
-                        'name': 'daily',
-                        'type': 'EventFilter',
-                        'api_version': 'core/v2'
-                    }
+                "name": "slack_alerts",
+                "filters": [
+                    {"name": "is_incident", "type": "EventFilter", "api_version": "core/v2"},
+                    {"name": "daily", "type": "EventFilter", "api_version": "core/v2"},
                 ],
-                'handler': {
-                    'name': 'slack',
-                    'type': 'Handler',
-                    'api_version': 'core/v2'
-                }
+                "handler": {"name": "slack", "type": "Handler", "api_version": "core/v2"},
             }
-        ]
+        ],
     },
     {
-        'metadata': {
-            'name': 'hard_state',
-            'namespace': 'default',
-            'labels': {'sensu.io/managed_by': 'sensuctl'},
-            'created_by': 'root'
+        "metadata": {
+            "name": "hard_state",
+            "namespace": "default",
+            "labels": {"sensu.io/managed_by": "sensuctl"},
+            "created_by": "root",
         },
-        'workflows': [
+        "workflows": [
             {
-                'name': 'mimic_hard_state',
-                'filters': [
-                    {
-                        'name': 'hard-state',
-                        'type': 'EventFilter',
-                        'api_version': 'core/v2'
-                    }
+                "name": "mimic_hard_state",
+                "filters": [
+                    {"name": "hard-state", "type": "EventFilter", "api_version": "core/v2"}
                 ],
-                'handler': {
-                    'name': 'publisher-handler',
-                    'type': 'Handler',
-                    'api_version': 'core/v2'
-                }
+                "handler": {
+                    "name": "publisher-handler",
+                    "type": "Handler",
+                    "api_version": "core/v2",
+                },
             }
-        ]
-    }
+        ],
+    },
 ]
 
 mock_events_ctl = [
     {
         "check": {
-            "command":
-                "/usr/lib64/nagios/plugins/check_ssl_cert -H "
-                "argo-mon-devel.ni4os.eu -t 90 -w 30 -c 0 -N --altnames "
-                "--rootcert-dir /etc/grid-security/certificates "
-                "--rootcert-file /etc/pki/tls/certs/ca-bundle.crt "
-                "-C /etc/sensu/certs/hostcert.pem "
-                "-K /etc/sensu/certs/hostkey.pem",
+            "command": "/usr/lib64/nagios/plugins/check_ssl_cert -H "
+            "argo-mon-devel.ni4os.eu -t 90 -w 30 -c 0 -N --altnames "
+            "--rootcert-dir /etc/grid-security/certificates "
+            "--rootcert-file /etc/pki/tls/certs/ca-bundle.crt "
+            "-C /etc/sensu/certs/hostcert.pem "
+            "-K /etc/sensu/certs/hostkey.pem",
             "handlers": [],
             "high_flap_threshold": 0,
             "interval": 14400,
             "low_flap_threshold": 0,
             "publish": True,
             "runtime_assets": None,
-            "subscriptions": [
-                "entity:sensu-agent1"
-            ],
+            "subscriptions": ["entity:sensu-agent1"],
             "proxy_entity_name": "argo.mon__argo-mon-devel.ni4os.eu",
             "check_hooks": None,
             "stdin": False,
@@ -1334,63 +1075,31 @@ mock_events_ctl = [
             "proxy_requests": {
                 "entity_attributes": [
                     "entity.entity_class == 'proxy'",
-                    "entity.labels.generic_certificate_validity == "
-                    "'generic.certificate.validity'"
+                    "entity.labels.generic_certificate_validity == 'generic.certificate.validity'",
                 ],
                 "splay": False,
-                "splay_coverage": 0
+                "splay_coverage": 0,
             },
             "round_robin": False,
             "duration": 12.389719077,
             "executed": 1677666193,
             "history": [
-                {
-                    "status": 0,
-                    "executed": 1677579792
-                },
-                {
-                    "status": 0,
-                    "executed": 1677579792
-                },
-                {
-                    "status": 0,
-                    "executed": 1677594191
-                },
-                {
-                    "status": 0,
-                    "executed": 1677608592
-                },
-                {
-                    "status": 0,
-                    "executed": 1677622992
-                },
-                {
-                    "status": 0,
-                    "executed": 1677637392
-                },
-                {
-                    "status": 0,
-                    "executed": 1677637392
-                },
-                {
-                    "status": 0,
-                    "executed": 1677651793
-                },
-                {
-                    "status": 0,
-                    "executed": 1677651793
-                },
-                {
-                    "status": 0,
-                    "executed": 1677666193
-                }
+                {"status": 0, "executed": 1677579792},
+                {"status": 0, "executed": 1677579792},
+                {"status": 0, "executed": 1677594191},
+                {"status": 0, "executed": 1677608592},
+                {"status": 0, "executed": 1677622992},
+                {"status": 0, "executed": 1677637392},
+                {"status": 0, "executed": 1677637392},
+                {"status": 0, "executed": 1677651793},
+                {"status": 0, "executed": 1677651793},
+                {"status": 0, "executed": 1677666193},
             ],
             "issued": 1677666193,
-            "output":
-                "SSL_CERT OK - x509 certificate '*.ni4os.eu' "
-                "(argo-mon-devel.ni4os.eu) from 'GEANT OV RSA CA 4' valid "
-                "until Apr 14 23:59:59 2023 GMT (expires in 44 days)|"
-                "days=44;30;0;;\n",
+            "output": "SSL_CERT OK - x509 certificate '*.ni4os.eu' "
+            "(argo-mon-devel.ni4os.eu) from 'GEANT OV RSA CA 4' valid "
+            "until Apr 14 23:59:59 2023 GMT (expires in 44 days)|"
+            "days=44;30;0;;\n",
             "state": "passing",
             "status": 0,
             "total_state_change": 0,
@@ -1403,36 +1112,24 @@ mock_events_ctl = [
             "metadata": {
                 "name": "generic.certificate.validity",
                 "namespace": "default",
-                "annotations": {
-                    "attempts": "2"
-                },
-                "labels": {
-                    "tenants": "ni4os"
-                }
+                "annotations": {"attempts": "2"},
+                "labels": {"tenants": "ni4os"},
             },
             "secrets": None,
             "is_silenced": False,
             "scheduler": "",
             "processed_by": "sensu-agent-ni4os-devel.cro-ngi",
-            "pipelines": [
-                {
-                    "name": "hard_state",
-                    "type": "Pipeline",
-                    "api_version": "core/v2"
-                }
-            ]
+            "pipelines": [{"name": "hard_state", "type": "Pipeline", "api_version": "core/v2"}],
         },
         "entity": {
             "entity_class": "proxy",
             "system": {
-                "network": {
-                    "interfaces": None
-                },
+                "network": {"interfaces": None},
                 "libc_type": "",
                 "vm_system": "",
                 "vm_role": "",
                 "cloud_provider": "",
-                "processes": None
+                "processes": None,
             },
             "subscriptions": None,
             "last_seen": 0,
@@ -1442,50 +1139,37 @@ mock_events_ctl = [
                 "name": "argo.mon__argo-mon-devel.ni4os.eu",
                 "namespace": "default",
                 "labels": {
-                    "generic_certificate_validity":
-                        "generic.certificate.validity",
-                    "generic_http_connect_nagios_ui":
-                        "generic.http.connect-nagios-ui",
+                    "generic_certificate_validity": "generic.certificate.validity",
+                    "generic_http_connect_nagios_ui": "generic.http.connect-nagios-ui",
                     "hostname": "argo-mon-devel.ni4os.eu",
                     "info_url": "https://argo-mon-devel.ni4os.eu",
                     "service": "argo.mon",
                     "site": "SRCE",
-                    "tenants": "ni4os"
-                }
+                    "tenants": "ni4os",
+                },
             },
-            "sensu_agent_version": ""
+            "sensu_agent_version": "",
         },
         "id": "xxxx",
-        "metadata": {
-            "namespace": "default"
-        },
-        "pipelines": [
-            {
-                "name": "hard_state",
-                "type": "Pipeline",
-                "api_version": "core/v2"
-            }
-        ],
+        "metadata": {"namespace": "default"},
+        "pipelines": [{"name": "hard_state", "type": "Pipeline", "api_version": "core/v2"}],
         "sequence": 751,
-        "timestamp": 1677666206
+        "timestamp": 1677666206,
     },
     {
         "check": {
-            "command":
-                "/usr/lib64/nagios/plugins/check_http -H "
-                "argo-mon-devel.ni4os.eu -t 30 --ssl -s \"Status Details\" "
-                "-u \"/nagios/cgi-bin/status.cgi?hostgroup=all&style="
-                "hostdetail\" -J /etc/sensu/certs/hostcert.pem "
-                "-K /etc/sensu/certs/hostkey.pem",
+            "command": "/usr/lib64/nagios/plugins/check_http -H "
+            'argo-mon-devel.ni4os.eu -t 30 --ssl -s "Status Details" '
+            '-u "/nagios/cgi-bin/status.cgi?hostgroup=all&style='
+            'hostdetail" -J /etc/sensu/certs/hostcert.pem '
+            "-K /etc/sensu/certs/hostkey.pem",
             "handlers": [],
             "high_flap_threshold": 0,
             "interval": 300,
             "low_flap_threshold": 0,
             "publish": True,
             "runtime_assets": None,
-            "subscriptions": [
-                "entity:sensu-agent1"
-            ],
+            "subscriptions": ["entity:sensu-agent1"],
             "proxy_entity_name": "argo.mon__argo-mon-devel.ni4os.eu",
             "check_hooks": None,
             "stdin": False,
@@ -1496,104 +1180,40 @@ mock_events_ctl = [
                 "entity_attributes": [
                     "entity.entity_class == 'proxy'",
                     "entity.labels.generic_http_connect_nagios_ui == "
-                    "'generic.http.connect-nagios-ui'"
+                    "'generic.http.connect-nagios-ui'",
                 ],
                 "splay": False,
-                "splay_coverage": 0
+                "splay_coverage": 0,
             },
             "round_robin": False,
             "duration": 0.055498604,
             "executed": 1677666496,
             "history": [
-                {
-                    "status": 0,
-                    "executed": 1677660496
-                },
-                {
-                    "status": 0,
-                    "executed": 1677660796
-                },
-                {
-                    "status": 0,
-                    "executed": 1677661096
-                },
-                {
-                    "status": 0,
-                    "executed": 1677661396
-                },
-                {
-                    "status": 0,
-                    "executed": 1677661696
-                },
-                {
-                    "status": 0,
-                    "executed": 1677661996
-                },
-                {
-                    "status": 0,
-                    "executed": 1677662296
-                },
-                {
-                    "status": 0,
-                    "executed": 1677662596
-                },
-                {
-                    "status": 0,
-                    "executed": 1677662896
-                },
-                {
-                    "status": 0,
-                    "executed": 1677663196
-                },
-                {
-                    "status": 0,
-                    "executed": 1677663496
-                },
-                {
-                    "status": 0,
-                    "executed": 1677663796
-                },
-                {
-                    "status": 0,
-                    "executed": 1677664096
-                },
-                {
-                    "status": 0,
-                    "executed": 1677664396
-                },
-                {
-                    "status": 0,
-                    "executed": 1677664696
-                },
-                {
-                    "status": 0,
-                    "executed": 1677664996
-                },
-                {
-                    "status": 0,
-                    "executed": 1677665296
-                },
-                {
-                    "status": 0,
-                    "executed": 1677665596
-                },
-                {
-                    "status": 0,
-                    "executed": 1677665896
-                },
-                {
-                    "status": 0,
-                    "executed": 1677666196
-                },
-                {
-                    "status": 0,
-                    "executed": 1677666496
-                }
+                {"status": 0, "executed": 1677660496},
+                {"status": 0, "executed": 1677660796},
+                {"status": 0, "executed": 1677661096},
+                {"status": 0, "executed": 1677661396},
+                {"status": 0, "executed": 1677661696},
+                {"status": 0, "executed": 1677661996},
+                {"status": 0, "executed": 1677662296},
+                {"status": 0, "executed": 1677662596},
+                {"status": 0, "executed": 1677662896},
+                {"status": 0, "executed": 1677663196},
+                {"status": 0, "executed": 1677663496},
+                {"status": 0, "executed": 1677663796},
+                {"status": 0, "executed": 1677664096},
+                {"status": 0, "executed": 1677664396},
+                {"status": 0, "executed": 1677664696},
+                {"status": 0, "executed": 1677664996},
+                {"status": 0, "executed": 1677665296},
+                {"status": 0, "executed": 1677665596},
+                {"status": 0, "executed": 1677665896},
+                {"status": 0, "executed": 1677666196},
+                {"status": 0, "executed": 1677666496},
             ],
             "issued": 1677666496,
-            "output":
-                "HTTP OK: HTTP/1.1 200 OK - 121268 bytes in 0.051 second "
-                "response time |time=0.050596s;;;0.000000 size=121268B;;;0\n",
+            "output": "HTTP OK: HTTP/1.1 200 OK - 121268 bytes in 0.051 second "
+            "response time |time=0.050596s;;;0.000000 size=121268B;;;0\n",
             "state": "passing",
             "status": 0,
             "total_state_change": 0,
@@ -1606,36 +1226,24 @@ mock_events_ctl = [
             "metadata": {
                 "name": "generic.http.connect-nagios-ui",
                 "namespace": "default",
-                "annotations": {
-                    "attempts": "3"
-                },
-                "labels": {
-                    "tenants": "ni4os"
-                }
+                "annotations": {"attempts": "3"},
+                "labels": {"tenants": "ni4os"},
             },
             "secrets": None,
             "is_silenced": False,
             "scheduler": "",
             "processed_by": "sensu-agent-ni4os-devel.cro-ngi",
-            "pipelines": [
-                {
-                    "name": "hard_state",
-                    "type": "Pipeline",
-                    "api_version": "core/v2"
-                }
-            ]
+            "pipelines": [{"name": "hard_state", "type": "Pipeline", "api_version": "core/v2"}],
         },
         "entity": {
             "entity_class": "proxy",
             "system": {
-                "network": {
-                    "interfaces": None
-                },
+                "network": {"interfaces": None},
                 "libc_type": "",
                 "vm_system": "",
                 "vm_role": "",
                 "cloud_provider": "",
-                "processes": None
+                "processes": None,
             },
             "subscriptions": None,
             "last_seen": 0,
@@ -1645,49 +1253,36 @@ mock_events_ctl = [
                 "name": "argo.mon__argo-mon-devel.ni4os.eu",
                 "namespace": "default",
                 "labels": {
-                    "generic_certificate_validity":
-                        "generic.certificate.validity",
-                    "generic_http_connect_nagios_ui":
-                        "generic.http.connect-nagios-ui",
+                    "generic_certificate_validity": "generic.certificate.validity",
+                    "generic_http_connect_nagios_ui": "generic.http.connect-nagios-ui",
                     "hostname": "argo-mon-devel.ni4os.eu",
                     "info_url": "https://argo-mon-devel.ni4os.eu",
                     "service": "argo.mon",
                     "site": "SRCE",
-                    "tenants": "ni4os"
-                }
+                    "tenants": "ni4os",
+                },
             },
-            "sensu_agent_version": ""
+            "sensu_agent_version": "",
         },
         "id": "xxxx",
-        "metadata": {
-            "namespace": "default"
-        },
-        "pipelines": [
-            {
-                "name": "hard_state",
-                "type": "Pipeline",
-                "api_version": "core/v2"
-            }
-        ],
+        "metadata": {"namespace": "default"},
+        "pipelines": [{"name": "hard_state", "type": "Pipeline", "api_version": "core/v2"}],
         "sequence": 931,
-        "timestamp": 1677666496
+        "timestamp": 1677666496,
     },
     {
         "check": {
-            "command":
-                "source /etc/sensu/secret_envs ; export $(cut -d= -f1 "
-                "/etc/sensu/secret_envs) ; "
-                "/usr/libexec/argo/probes/grnet-agora/checkhealth "
-                "-H agora.ni4os.eu -v -i -u $AGORA_USERNAME -p $AGORA_PASSWORD",
+            "command": "source /etc/sensu/secret_envs ; export $(cut -d= -f1 "
+            "/etc/sensu/secret_envs) ; "
+            "/usr/libexec/argo/probes/grnet-agora/checkhealth "
+            "-H agora.ni4os.eu -v -i -u $AGORA_USERNAME -p $AGORA_PASSWORD",
             "handlers": [],
             "high_flap_threshold": 0,
             "interval": 900,
             "low_flap_threshold": 0,
             "publish": True,
             "runtime_assets": None,
-            "subscriptions": [
-                "entity:sensu-agent1"
-            ],
+            "subscriptions": ["entity:sensu-agent1"],
             "proxy_entity_name": "eu.eudat.itsm.spmt__agora.ni4os.eu",
             "check_hooks": None,
             "stdin": False,
@@ -1697,44 +1292,22 @@ mock_events_ctl = [
             "proxy_requests": {
                 "entity_attributes": [
                     "entity.entity_class == 'proxy'",
-                    "entity.labels.grnet_agora_healthcheck == "
-                    "'grnet.agora.healthcheck'"
+                    "entity.labels.grnet_agora_healthcheck == 'grnet.agora.healthcheck'",
                 ],
                 "splay": False,
-                "splay_coverage": 0
+                "splay_coverage": 0,
             },
             "round_robin": False,
             "duration": 22.136456263,
             "executed": 1682322850,
             "history": [
-                {
-                    "status": 0,
-                    "executed": 1682304850
-                },
-                {
-                    "status": 0,
-                    "executed": 1682305750
-                },
-                {
-                    "status": 0,
-                    "executed": 1682306650
-                },
-                {
-                    "status": 0,
-                    "executed": 1682307550
-                },
-                {
-                    "status": 0,
-                    "executed": 1682308450
-                },
-                {
-                    "status": 0,
-                    "executed": 1682309350
-                },
-                {
-                    "status": 0,
-                    "executed": 1682310250
-                }
+                {"status": 0, "executed": 1682304850},
+                {"status": 0, "executed": 1682305750},
+                {"status": 0, "executed": 1682306650},
+                {"status": 0, "executed": 1682307550},
+                {"status": 0, "executed": 1682308450},
+                {"status": 0, "executed": 1682309350},
+                {"status": 0, "executed": 1682310250},
             ],
             "issued": 1682322850,
             "output": "OK - Agora is up.\n",
@@ -1750,36 +1323,24 @@ mock_events_ctl = [
             "metadata": {
                 "name": "grnet.agora.healthcheck",
                 "namespace": "default",
-                "annotations": {
-                    "attempts": "3"
-                },
-                "labels": {
-                    "tenants": "ni4os"
-                }
+                "annotations": {"attempts": "3"},
+                "labels": {"tenants": "ni4os"},
             },
             "secrets": None,
             "is_silenced": False,
             "scheduler": "",
             "processed_by": "sensu-agent-ni4os-devel.cro-ngi",
-            "pipelines": [
-                {
-                    "name": "hard_state",
-                    "type": "Pipeline",
-                    "api_version": "core/v2"
-                }
-            ]
+            "pipelines": [{"name": "hard_state", "type": "Pipeline", "api_version": "core/v2"}],
         },
         "entity": {
             "entity_class": "proxy",
             "system": {
-                "network": {
-                    "interfaces": None
-                },
+                "network": {"interfaces": None},
                 "libc_type": "",
                 "vm_system": "",
                 "vm_role": "",
                 "cloud_provider": "",
-                "processes": None
+                "processes": None,
             },
             "subscriptions": None,
             "last_seen": 0,
@@ -1794,45 +1355,33 @@ mock_events_ctl = [
                     "info_url": "agora.ni4os.eu",
                     "service": "eu.eudat.itsm.spmt",
                     "site": "GRNET",
-                    "tenants": "ni4os"
-                }
+                    "tenants": "ni4os",
+                },
             },
-            "sensu_agent_version": ""
+            "sensu_agent_version": "",
         },
         "id": "xxx",
-        "metadata": {
-            "namespace": "default"
-        },
-        "pipelines": [
-            {
-                "name": "hard_state",
-                "type": "Pipeline",
-                "api_version": "core/v2"
-            }
-        ],
+        "metadata": {"namespace": "default"},
+        "pipelines": [{"name": "hard_state", "type": "Pipeline", "api_version": "core/v2"}],
         "sequence": 1731,
-        "timestamp": 1682322872
+        "timestamp": 1682322872,
     },
     {
         "check": {
-            "command":
-                "/usr/lib64/nagios/plugins/check_ssl_cert "
-                "-H cherry.chem.bg.ac.rs -t 90 -w 30 -c 0 -N --altnames "
-                "--rootcert-dir /etc/grid-security/certificates "
-                "--rootcert-file /etc/pki/tls/certs/ca-bundle.crt "
-                "-C /etc/sensu/certs/hostcert.pem "
-                "-K /etc/sensu/certs/hostkey.pem",
+            "command": "/usr/lib64/nagios/plugins/check_ssl_cert "
+            "-H cherry.chem.bg.ac.rs -t 90 -w 30 -c 0 -N --altnames "
+            "--rootcert-dir /etc/grid-security/certificates "
+            "--rootcert-file /etc/pki/tls/certs/ca-bundle.crt "
+            "-C /etc/sensu/certs/hostcert.pem "
+            "-K /etc/sensu/certs/hostkey.pem",
             "handlers": [],
             "high_flap_threshold": 0,
             "interval": 14400,
             "low_flap_threshold": 0,
             "publish": True,
             "runtime_assets": None,
-            "subscriptions": [
-                "entity:sensu-agent1"
-            ],
-            "proxy_entity_name":
-                "eu.ni4os.repo.publication__cherry.chem.bg.ac.rs",
+            "subscriptions": ["entity:sensu-agent1"],
+            "proxy_entity_name": "eu.ni4os.repo.publication__cherry.chem.bg.ac.rs",
             "check_hooks": None,
             "stdin": False,
             "subdue": None,
@@ -1841,66 +1390,31 @@ mock_events_ctl = [
             "proxy_requests": {
                 "entity_attributes": [
                     "entity.entity_class == 'proxy'",
-                    "entity.labels.generic_certificate_validity == "
-                    "'generic.certificate.validity'"
+                    "entity.labels.generic_certificate_validity == 'generic.certificate.validity'",
                 ],
                 "splay": False,
-                "splay_coverage": 0
+                "splay_coverage": 0,
             },
             "round_robin": False,
             "duration": 15.543039693,
             "executed": 1682317397,
             "history": [
-                {
-                    "status": 0,
-                    "executed": 1682101396
-                },
-                {
-                    "status": 0,
-                    "executed": 1682115796
-                },
-                {
-                    "status": 0,
-                    "executed": 1682130196
-                },
-                {
-                    "status": 1,
-                    "executed": 1682144596
-                },
-                {
-                    "status": 1,
-                    "executed": 1682158996
-                },
-                {
-                    "status": 1,
-                    "executed": 1682158996
-                },
-                {
-                    "status": 1,
-                    "executed": 1682158996
-                },
-                {
-                    "status": 1,
-                    "executed": 1682173396
-                },
-                {
-                    "status": 1,
-                    "executed": 1682187796
-                },
-                {
-                    "status": 0,
-                    "executed": 1682202197
-                },
-                {
-                    "status": 0,
-                    "executed": 1682202197
-                }
+                {"status": 0, "executed": 1682101396},
+                {"status": 0, "executed": 1682115796},
+                {"status": 0, "executed": 1682130196},
+                {"status": 1, "executed": 1682144596},
+                {"status": 1, "executed": 1682158996},
+                {"status": 1, "executed": 1682158996},
+                {"status": 1, "executed": 1682158996},
+                {"status": 1, "executed": 1682173396},
+                {"status": 1, "executed": 1682187796},
+                {"status": 0, "executed": 1682202197},
+                {"status": 0, "executed": 1682202197},
             ],
             "issued": 1682317397,
-            "output":
-                "SSL_CERT OK - x509 certificate 'cherry.chem.bg.ac.rs' from "
-                "'R3' valid until Jul 21 19:32:45 2023 GMT (expires in 88 days)"
-                "|days=88;30;0;;\n",
+            "output": "SSL_CERT OK - x509 certificate 'cherry.chem.bg.ac.rs' from "
+            "'R3' valid until Jul 21 19:32:45 2023 GMT (expires in 88 days)"
+            "|days=88;30;0;;\n",
             "state": "passing",
             "status": 0,
             "total_state_change": 9,
@@ -1913,36 +1427,24 @@ mock_events_ctl = [
             "metadata": {
                 "name": "generic.certificate.validity",
                 "namespace": "default",
-                "annotations": {
-                    "attempts": "2"
-                },
-                "labels": {
-                    "tenants": "ni4os"
-                }
+                "annotations": {"attempts": "2"},
+                "labels": {"tenants": "ni4os"},
             },
             "secrets": None,
             "is_silenced": False,
             "scheduler": "",
             "processed_by": "sensu-agent-ni4os-devel.cro-ngi",
-            "pipelines": [
-                {
-                    "name": "hard_state",
-                    "type": "Pipeline",
-                    "api_version": "core/v2"
-                }
-            ]
+            "pipelines": [{"name": "hard_state", "type": "Pipeline", "api_version": "core/v2"}],
         },
         "entity": {
             "entity_class": "proxy",
             "system": {
-                "network": {
-                    "interfaces": None
-                },
+                "network": {"interfaces": None},
                 "libc_type": "",
                 "vm_system": "",
                 "vm_role": "",
                 "cloud_provider": "",
-                "processes": None
+                "processes": None,
             },
             "subscriptions": None,
             "last_seen": 0,
@@ -1952,8 +1454,7 @@ mock_events_ctl = [
                 "name": "eu.ni4os.repo.publication__cherry.chem.bg.ac.rs",
                 "namespace": "default",
                 "labels": {
-                    "generic_certificate_validity":
-                        "generic.certificate.validity",
+                    "generic_certificate_validity": "generic.certificate.validity",
                     "generic_http_connect": "generic.http.connect",
                     "hostname": "cherry.chem.bg.ac.rs",
                     "info_url": "https://cherry.chem.bg.ac.rs/",
@@ -1962,43 +1463,32 @@ mock_events_ctl = [
                     "service": "eu.ni4os.repo.publication",
                     "site": "RCUB",
                     "ssl": "-S --sni",
-                    "tenants": "ni4os"
-                }
+                    "tenants": "ni4os",
+                },
             },
-            "sensu_agent_version": ""
+            "sensu_agent_version": "",
         },
         "id": "xxx",
-        "metadata": {
-            "namespace": "default"
-        },
-        "pipelines": [
-            {
-                "name": "hard_state",
-                "type": "Pipeline",
-                "api_version": "core/v2"
-            }
-        ],
+        "metadata": {"namespace": "default"},
+        "pipelines": [{"name": "hard_state", "type": "Pipeline", "api_version": "core/v2"}],
         "sequence": 13474,
-        "timestamp": 1682317412
+        "timestamp": 1682317412,
     },
     {
         "check": {
-            "command":
-                "/usr/lib64/nagios/plugins/check_ssl_cert -H videolectures.net "
-                "-t 90 -w 30 -c 0 -N --altnames "
-                "--rootcert-dir /etc/grid-security/certificates "
-                "--rootcert-file /etc/pki/tls/certs/ca-bundle.crt "
-                "-C /etc/sensu/certs/hostcert.pem "
-                "-K /etc/sensu/certs/hostkey.pem",
+            "command": "/usr/lib64/nagios/plugins/check_ssl_cert -H videolectures.net "
+            "-t 90 -w 30 -c 0 -N --altnames "
+            "--rootcert-dir /etc/grid-security/certificates "
+            "--rootcert-file /etc/pki/tls/certs/ca-bundle.crt "
+            "-C /etc/sensu/certs/hostcert.pem "
+            "-K /etc/sensu/certs/hostkey.pem",
             "handlers": [],
             "high_flap_threshold": 0,
             "interval": 14400,
             "low_flap_threshold": 0,
             "publish": True,
             "runtime_assets": None,
-            "subscriptions": [
-                "entity:sensu-agent1"
-            ],
+            "subscriptions": ["entity:sensu-agent1"],
             "proxy_entity_name": "eu.ni4os.repo.publication__videolectures.net",
             "check_hooks": None,
             "stdin": False,
@@ -2008,58 +1498,29 @@ mock_events_ctl = [
             "proxy_requests": {
                 "entity_attributes": [
                     "entity.entity_class == 'proxy'",
-                    "entity.labels.generic_certificate_validity == "
-                    "'generic.certificate.validity'"
+                    "entity.labels.generic_certificate_validity == 'generic.certificate.validity'",
                 ],
                 "splay": False,
-                "splay_coverage": 0
+                "splay_coverage": 0,
             },
             "round_robin": False,
             "duration": 17.61893143,
             "executed": 1677666193,
             "history": [
-                {
-                    "status": 2,
-                    "executed": 1677579792
-                },
-                {
-                    "status": 2,
-                    "executed": 1677594191
-                },
-                {
-                    "status": 2,
-                    "executed": 1677608592
-                },
-                {
-                    "status": 2,
-                    "executed": 1677622992
-                },
-                {
-                    "status": 2,
-                    "executed": 1677637392
-                },
-                {
-                    "status": 2,
-                    "executed": 1677651793
-                },
-                {
-                    "status": 2,
-                    "executed": 1677651793
-                },
-                {
-                    "status": 2,
-                    "executed": 1677651793
-                },
-                {
-                    "status": 2,
-                    "executed": 1677666193
-                }
+                {"status": 2, "executed": 1677579792},
+                {"status": 2, "executed": 1677594191},
+                {"status": 2, "executed": 1677608592},
+                {"status": 2, "executed": 1677622992},
+                {"status": 2, "executed": 1677637392},
+                {"status": 2, "executed": 1677651793},
+                {"status": 2, "executed": 1677651793},
+                {"status": 2, "executed": 1677651793},
+                {"status": 2, "executed": 1677666193},
             ],
             "issued": 1677666193,
-            "output":
-                "SSL_CERT CRITICAL videolectures.net: x509 certificate is "
-                "expired (was valid until Jul 10 07:29:06 2022 GMT)|"
-                "days=-234;30;0;;\n",
+            "output": "SSL_CERT CRITICAL videolectures.net: x509 certificate is "
+            "expired (was valid until Jul 10 07:29:06 2022 GMT)|"
+            "days=-234;30;0;;\n",
             "state": "failing",
             "status": 2,
             "total_state_change": 0,
@@ -2072,36 +1533,24 @@ mock_events_ctl = [
             "metadata": {
                 "name": "generic.certificate.validity",
                 "namespace": "default",
-                "annotations": {
-                    "attempts": "2"
-                },
-                "labels": {
-                    "tenants": "ni4os"
-                }
+                "annotations": {"attempts": "2"},
+                "labels": {"tenants": "ni4os"},
             },
             "secrets": None,
             "is_silenced": False,
             "scheduler": "",
             "processed_by": "sensu-agent-ni4os-devel.cro-ngi",
-            "pipelines": [
-                {
-                    "name": "hard_state",
-                    "type": "Pipeline",
-                    "api_version": "core/v2"
-                }
-            ]
+            "pipelines": [{"name": "hard_state", "type": "Pipeline", "api_version": "core/v2"}],
         },
         "entity": {
             "entity_class": "proxy",
             "system": {
-                "network": {
-                    "interfaces": None
-                },
+                "network": {"interfaces": None},
                 "libc_type": "",
                 "vm_system": "",
                 "vm_role": "",
                 "cloud_provider": "",
-                "processes": None
+                "processes": None,
             },
             "subscriptions": None,
             "last_seen": 0,
@@ -2111,8 +1560,7 @@ mock_events_ctl = [
                 "name": "eu.ni4os.repo.publication__videolectures.net",
                 "namespace": "default",
                 "labels": {
-                    "generic_certificate_validity":
-                        "generic.certificate.validity",
+                    "generic_certificate_validity": "generic.certificate.validity",
                     "hostname": "videolectures.net",
                     "info_url": "http://videolectures.net/",
                     "path": "/",
@@ -2120,40 +1568,29 @@ mock_events_ctl = [
                     "service": "eu.ni4os.repo.publication",
                     "site": "JSI",
                     "ssl": "",
-                    "tenants": "ni4os"
-                }
+                    "tenants": "ni4os",
+                },
             },
-            "sensu_agent_version": ""
+            "sensu_agent_version": "",
         },
         "id": "xxxx",
-        "metadata": {
-            "namespace": "default"
-        },
-        "pipelines": [
-            {
-                "name": "hard_state",
-                "type": "Pipeline",
-                "api_version": "core/v2"
-            }
-        ],
+        "metadata": {"namespace": "default"},
+        "pipelines": [{"name": "hard_state", "type": "Pipeline", "api_version": "core/v2"}],
         "sequence": 871,
-        "timestamp": 1677666211
+        "timestamp": 1677666211,
     },
     {
         "check": {
-            "command":
-                "/usr/libexec/argo/probes/argo_tools/check_log -t 120 --file "
-                "/var/log/argo-poem-tools/argo-poem-tools.log --age 2 --app "
-                "argo-poem-packages",
+            "command": "/usr/libexec/argo/probes/argo_tools/check_log -t 120 --file "
+            "/var/log/argo-poem-tools/argo-poem-tools.log --age 2 --app "
+            "argo-poem-packages",
             "handlers": [],
             "high_flap_threshold": 0,
             "interval": 7200,
             "low_flap_threshold": 0,
             "publish": True,
             "runtime_assets": None,
-            "subscriptions": [
-                "entity:sensu-agent1"
-            ],
+            "subscriptions": ["entity:sensu-agent1"],
             "proxy_entity_name": "",
             "check_hooks": None,
             "stdin": False,
@@ -2164,42 +1601,15 @@ mock_events_ctl = [
             "duration": 0.056187701,
             "executed": 1682322924,
             "history": [
-                {
-                    "status": 0,
-                    "executed": 1682178924
-                },
-                {
-                    "status": 0,
-                    "executed": 1682186124
-                },
-                {
-                    "status": 0,
-                    "executed": 1682193324
-                },
-                {
-                    "status": 0,
-                    "executed": 1682200524
-                },
-                {
-                    "status": 0,
-                    "executed": 1682207724
-                },
-                {
-                    "status": 0,
-                    "executed": 1682214924
-                },
-                {
-                    "status": 0,
-                    "executed": 1682222124
-                },
-                {
-                    "status": 0,
-                    "executed": 1682229324
-                },
-                {
-                    "status": 0,
-                    "executed": 1682236524
-                }
+                {"status": 0, "executed": 1682178924},
+                {"status": 0, "executed": 1682186124},
+                {"status": 0, "executed": 1682193324},
+                {"status": 0, "executed": 1682200524},
+                {"status": 0, "executed": 1682207724},
+                {"status": 0, "executed": 1682214924},
+                {"status": 0, "executed": 1682222124},
+                {"status": 0, "executed": 1682229324},
+                {"status": 0, "executed": 1682236524},
             ],
             "issued": 1682322924,
             "output": "OK - The run finished successfully.\n",
@@ -2215,24 +1625,14 @@ mock_events_ctl = [
             "metadata": {
                 "name": "argo.poem-tools.check",
                 "namespace": "default",
-                "annotations": {
-                    "attempts": "4"
-                },
-                "labels": {
-                    "tenants": "ni4os"
-                }
+                "annotations": {"attempts": "4"},
+                "labels": {"tenants": "ni4os"},
             },
             "secrets": None,
             "is_silenced": False,
             "scheduler": "memory",
             "processed_by": "sensu-agent-ni4os-devel.cro-ngi",
-            "pipelines": [
-                {
-                    "name": "reduce_alerts",
-                    "type": "Pipeline",
-                    "api_version": "core/v2"
-                }
-            ]
+            "pipelines": [{"name": "reduce_alerts", "type": "Pipeline", "api_version": "core/v2"}],
         },
         "entity": {
             "entity_class": "agent",
@@ -2247,7 +1647,7 @@ mock_events_ctl = [
                 "vm_system": "",
                 "vm_role": "guest",
                 "cloud_provider": "",
-                "processes": None
+                "processes": None,
             },
             "subscriptions": [
                 "entity:sensu-agent-ni4os-devel.cro-ngi",
@@ -2263,38 +1663,27 @@ mock_events_ctl = [
                 "labels": {
                     "hostname": "sensu-agent-ni4os-devel.cro-ngi",
                     "services": "argo.mon,argo.test",
-                }
+                },
             },
-            "sensu_agent_version": "6.7.1+oss_el7"
+            "sensu_agent_version": "6.7.1+oss_el7",
         },
         "id": "xxx",
-        "metadata": {
-            "namespace": "default"
-        },
-        "pipelines": [
-            {
-                "name": "reduce_alerts",
-                "type": "Pipeline",
-                "api_version": "core/v2"
-            }
-        ],
+        "metadata": {"namespace": "default"},
+        "pipelines": [{"name": "reduce_alerts", "type": "Pipeline", "api_version": "core/v2"}],
         "sequence": 217,
-        "timestamp": 1682322924
+        "timestamp": 1682322924,
     },
     {
         "check": {
-            "command":
-                "/usr/libexec/argo/probes/cert/CertLifetime-probe -t 60 "
-                "-f /etc/sensu/certs/hostcert.pem",
+            "command": "/usr/libexec/argo/probes/cert/CertLifetime-probe -t 60 "
+            "-f /etc/sensu/certs/hostcert.pem",
             "handlers": [],
             "high_flap_threshold": 0,
             "interval": 14400,
             "low_flap_threshold": 0,
             "publish": True,
             "runtime_assets": None,
-            "subscriptions": [
-                "entity:sensu-agent1"
-            ],
+            "subscriptions": ["entity:sensu-agent1"],
             "proxy_entity_name": "",
             "check_hooks": None,
             "stdin": False,
@@ -2305,39 +1694,17 @@ mock_events_ctl = [
             "duration": 0.122199784,
             "executed": 1682319670,
             "history": [
-                {
-                    "status": 0,
-                    "executed": 1682031669
-                },
-                {
-                    "status": 0,
-                    "executed": 1682046069
-                },
-                {
-                    "status": 0,
-                    "executed": 1682060469
-                },
-                {
-                    "status": 0,
-                    "executed": 1682074869
-                },
-                {
-                    "status": 0,
-                    "executed": 1682089269
-                },
-                {
-                    "status": 0,
-                    "executed": 1682103670
-                },
-                {
-                    "status": 0,
-                    "executed": 1682118070
-                }
+                {"status": 0, "executed": 1682031669},
+                {"status": 0, "executed": 1682046069},
+                {"status": 0, "executed": 1682060469},
+                {"status": 0, "executed": 1682074869},
+                {"status": 0, "executed": 1682089269},
+                {"status": 0, "executed": 1682103670},
+                {"status": 0, "executed": 1682118070},
             ],
             "issued": 1682319670,
-            "output":
-                "CERT LIFETIME OK - Certificate will expire in 373.99 days "
-                "(May  2 06:53:47 2024 GMT)\n",
+            "output": "CERT LIFETIME OK - Certificate will expire in 373.99 days "
+            "(May  2 06:53:47 2024 GMT)\n",
             "state": "passing",
             "status": 0,
             "total_state_change": 0,
@@ -2350,24 +1717,14 @@ mock_events_ctl = [
             "metadata": {
                 "name": "hr.srce.CertLifetime-Local",
                 "namespace": "default",
-                "annotations": {
-                    "attempts": "2"
-                },
-                "labels": {
-                    "tenants": "ni4os"
-                }
+                "annotations": {"attempts": "2"},
+                "labels": {"tenants": "ni4os"},
             },
             "secrets": None,
             "is_silenced": False,
             "scheduler": "memory",
             "processed_by": "sensu-agent-ni4os-devel.cro-ngi",
-            "pipelines": [
-                {
-                    "name": "reduce_alerts",
-                    "type": "Pipeline",
-                    "api_version": "core/v2"
-                }
-            ]
+            "pipelines": [{"name": "reduce_alerts", "type": "Pipeline", "api_version": "core/v2"}],
         },
         "entity": {
             "entity_class": "agent",
@@ -2382,12 +1739,9 @@ mock_events_ctl = [
                 "vm_system": "",
                 "vm_role": "guest",
                 "cloud_provider": "",
-                "processes": None
+                "processes": None,
             },
-            "subscriptions": [
-                "entity:sensu-agent-ni4os-devel.cro-ngi",
-                "ni4os"
-            ],
+            "subscriptions": ["entity:sensu-agent-ni4os-devel.cro-ngi", "ni4os"],
             "last_seen": 1682319670,
             "deregister": False,
             "deregistration": {},
@@ -2395,854 +1749,733 @@ mock_events_ctl = [
             "metadata": {
                 "name": "sensu-agent-ni4os-devel.cro-ngi",
                 "namespace": "default",
-                "labels": {
-                    "hostname": "sensu-agent-ni4os-devel.cro-ngi",
-                    "services": "argo.mon"
-                }
+                "labels": {"hostname": "sensu-agent-ni4os-devel.cro-ngi", "services": "argo.mon"},
             },
-            "sensu_agent_version": "6.7.1+oss_el7"
+            "sensu_agent_version": "6.7.1+oss_el7",
         },
         "id": "xxx",
-        "metadata": {
-            "namespace": "default"
-        },
-        "pipelines": [
-            {
-                "name": "reduce_alerts",
-                "type": "Pipeline",
-                "api_version": "core/v2"
-            }
-        ],
+        "metadata": {"namespace": "default"},
+        "pipelines": [{"name": "reduce_alerts", "type": "Pipeline", "api_version": "core/v2"}],
         "sequence": 108,
-        "timestamp": 1682319670
-    }
+        "timestamp": 1682319670,
+    },
 ]
 
 mock_events_multiline_ctl = [
     {
-        'check': {
-            'command': '/usr/libexec/argo/probes/htcondorce/'
-                       'htcondorce-cert-check -H ce503.cern.ch -t 60 '
-                       '--ca-bundle /etc/pki/tls/certs/ca-bundle.crt '
-                       '--user_proxy /etc/sensu/certs/userproxy.pem',
-            'handlers': [],
-            'high_flap_threshold': 0,
-            'interval': 86400,
-            'low_flap_threshold': 0,
-            'publish': True,
-            'runtime_assets': None,
-            'subscriptions': [
-                "entity:sensu-agent1"
-            ],
-            'proxy_entity_name':
-                'org.opensciencegrid.htcondorce__ce503.cern.ch',
-            'check_hooks': None,
-            'stdin': False,
-            'subdue': None,
-            'ttl': 0,
-            'timeout': 900,
-            'proxy_requests': {
-                'entity_attributes': [
+        "check": {
+            "command": "/usr/libexec/argo/probes/htcondorce/"
+            "htcondorce-cert-check -H ce503.cern.ch -t 60 "
+            "--ca-bundle /etc/pki/tls/certs/ca-bundle.crt "
+            "--user_proxy /etc/sensu/certs/userproxy.pem",
+            "handlers": [],
+            "high_flap_threshold": 0,
+            "interval": 86400,
+            "low_flap_threshold": 0,
+            "publish": True,
+            "runtime_assets": None,
+            "subscriptions": ["entity:sensu-agent1"],
+            "proxy_entity_name": "org.opensciencegrid.htcondorce__ce503.cern.ch",
+            "check_hooks": None,
+            "stdin": False,
+            "subdue": None,
+            "ttl": 0,
+            "timeout": 900,
+            "proxy_requests": {
+                "entity_attributes": [
                     "entity.entity_class == 'proxy'",
                     "entity.labels.argo_certificate_validity_htcondorce == "
-                    "'argo.certificate.validity-htcondorce'"
+                    "'argo.certificate.validity-htcondorce'",
                 ],
-                'splay': False,
-                'splay_coverage': 0
+                "splay": False,
+                "splay_coverage": 0,
             },
-            'round_robin': False,
-            'duration': 1.420389828,
-            'executed': 1704835943,
-            'history': [
-                {'status': 0, 'executed': 1704490341},
-                {'status': 0, 'executed': 1704576741},
-                {'status': 0, 'executed': 1704663142}
+            "round_robin": False,
+            "duration": 1.420389828,
+            "executed": 1704835943,
+            "history": [
+                {"status": 0, "executed": 1704490341},
+                {"status": 0, "executed": 1704576741},
+                {"status": 0, "executed": 1704663142},
             ],
-            'issued': 1704835943,
-            'output':
-                'OK - HTCondorCE certificate valid until Jul 11 10:51:04 2024 '
-                'UTC (expires in 183 days)\n',
-            'state': 'passing',
-            'status': 0,
-            'total_state_change': 0,
-            'last_ok': 1704835943,
-            'occurrences': 3,
-            'occurrences_watermark': 3,
-            'output_metric_format': '',
-            'output_metric_handlers': None,
-            'env_vars': None,
-            'metadata': {
-                'name': 'argo.certificate.validity-htcondorce',
-                'namespace': 'default',
-                'annotations': {'attempts': '2'},
+            "issued": 1704835943,
+            "output": "OK - HTCondorCE certificate valid until Jul 11 10:51:04 2024 "
+            "UTC (expires in 183 days)\n",
+            "state": "passing",
+            "status": 0,
+            "total_state_change": 0,
+            "last_ok": 1704835943,
+            "occurrences": 3,
+            "occurrences_watermark": 3,
+            "output_metric_format": "",
+            "output_metric_handlers": None,
+            "env_vars": None,
+            "metadata": {
+                "name": "argo.certificate.validity-htcondorce",
+                "namespace": "default",
+                "annotations": {"attempts": "2"},
+                "labels": {"tenants": "ni4os"},
+            },
+            "secrets": None,
+            "is_silenced": False,
+            "scheduler": "",
+            "processed_by": "sensu-agent-egi-htcondor-devel.cro-ngi",
+            "pipelines": [{"name": "hard_state", "type": "Pipeline", "api_version": "core/v2"}],
+        },
+        "entity": {
+            "entity_class": "proxy",
+            "subscriptions": None,
+            "last_seen": 0,
+            "deregister": False,
+            "deregistration": {},
+            "metadata": {
+                "name": "org.opensciencegrid.htcondorce__ce503.cern.ch",
+                "namespace": "default",
                 "labels": {
-                    "tenants": "ni4os"
-                }
+                    "argo_certificate_validity_htcondorce": "argo.certificate.validity-htcondorce",
+                    "ch_cern_htcondorce_jobstate": "ch.cern.HTCondorCE-JobState",
+                    "ch_cern_htcondorce_jobstate_pool": "ce503.cern.ch:9619",
+                    "ch_cern_htcondorce_jobstate_resource": "condor-ce://ce503.cern.ch/ce503.cern.ch/nopbs/noqueue",
+                    "ch_cern_htcondorce_jobstate_schedd": "ce503.cern.ch",
+                    "ch_cern_htcondorce_jobsubmit": "ch.cern.HTCondorCE-JobSubmit",
+                    "hostname": "ce503.cern.ch",
+                    "service": "org.opensciencegrid.htcondorce",
+                    "site": "CERN-PROD",
+                    "site_bdii": "site-bdii.cern.ch",
+                    "tenants": "ni4os",
+                },
             },
-            'secrets': None,
-            'is_silenced': False,
-            'scheduler': '',
-            'processed_by': 'sensu-agent-egi-htcondor-devel.cro-ngi',
-            'pipelines': [{
-                'name': 'hard_state',
-                'type': 'Pipeline',
-                'api_version': 'core/v2'
-            }]
+            "sensu_agent_version": "",
         },
-        'entity': {
-            'entity_class': 'proxy',
-            'subscriptions': None,
-            'last_seen': 0,
-            'deregister': False,
-            'deregistration': {},
-            'metadata': {
-                'name': 'org.opensciencegrid.htcondorce__ce503.cern.ch',
-                'namespace': 'default',
-                'labels': {
-                    'argo_certificate_validity_htcondorce':
-                        'argo.certificate.validity-htcondorce',
-                    'ch_cern_htcondorce_jobstate':
-                        'ch.cern.HTCondorCE-JobState',
-                    'ch_cern_htcondorce_jobstate_pool': 'ce503.cern.ch:9619',
-                    'ch_cern_htcondorce_jobstate_resource':
-                        'condor-ce://ce503.cern.ch/ce503.cern.ch/nopbs/noqueue',
-                    'ch_cern_htcondorce_jobstate_schedd': 'ce503.cern.ch',
-                    'ch_cern_htcondorce_jobsubmit':
-                        'ch.cern.HTCondorCE-JobSubmit',
-                    'hostname': 'ce503.cern.ch',
-                    'service': 'org.opensciencegrid.htcondorce',
-                    'site': 'CERN-PROD',
-                    'site_bdii': 'site-bdii.cern.ch',
-                    "tenants": "ni4os"
-                }
-            },
-            'sensu_agent_version': ''
-        },
-        'id': 'xxxx',
-        'metadata': {'namespace': 'default'},
-        'pipelines': [{
-            'name': 'hard_state', 'type': 'Pipeline', 'api_version': 'core/v2'
-        }],
-        'sequence': 461,
-        'timestamp': 1704835944
-    }, {
-        'check': {
-            'command':
-                "/usr/lib64/nagios/plugins/check_js -H ce503.cern.ch -t 600 "
-                "--executable /bin/hostname --resource "
-                "condor-ce://ce503.cern.ch/ce503.cern.ch/nopbs/noqueue "
-                "--backend scondor --pool ce503.cern.ch:9619 "
-                "--schedd ce503.cern.ch --zero-payload --jdl-ads "
-                "'+Owner = undefined' --prefix ch.cern.HTCondorCE "
-                "--suffix ops --vo ops -x /etc/sensu/certs/userproxy.pem",
-            'handlers': [],
-            'high_flap_threshold': 0,
-            'interval': 3600,
-            'low_flap_threshold': 0,
-            'publish': True,
-            'runtime_assets': None,
-            'subscriptions': [
-                "entity:sensu-agent1"
-            ],
-            'proxy_entity_name':
-                'org.opensciencegrid.htcondorce__ce503.cern.ch',
-            'check_hooks': None,
-            'stdin': False,
-            'subdue': None,
-            'ttl': 0,
-            'timeout': 900,
-            'proxy_requests': {
-                'entity_attributes': [
+        "id": "xxxx",
+        "metadata": {"namespace": "default"},
+        "pipelines": [{"name": "hard_state", "type": "Pipeline", "api_version": "core/v2"}],
+        "sequence": 461,
+        "timestamp": 1704835944,
+    },
+    {
+        "check": {
+            "command": "/usr/lib64/nagios/plugins/check_js -H ce503.cern.ch -t 600 "
+            "--executable /bin/hostname --resource "
+            "condor-ce://ce503.cern.ch/ce503.cern.ch/nopbs/noqueue "
+            "--backend scondor --pool ce503.cern.ch:9619 "
+            "--schedd ce503.cern.ch --zero-payload --jdl-ads "
+            "'+Owner = undefined' --prefix ch.cern.HTCondorCE "
+            "--suffix ops --vo ops -x /etc/sensu/certs/userproxy.pem",
+            "handlers": [],
+            "high_flap_threshold": 0,
+            "interval": 3600,
+            "low_flap_threshold": 0,
+            "publish": True,
+            "runtime_assets": None,
+            "subscriptions": ["entity:sensu-agent1"],
+            "proxy_entity_name": "org.opensciencegrid.htcondorce__ce503.cern.ch",
+            "check_hooks": None,
+            "stdin": False,
+            "subdue": None,
+            "ttl": 0,
+            "timeout": 900,
+            "proxy_requests": {
+                "entity_attributes": [
                     "entity.entity_class == 'proxy'",
-                    "entity.labels.ch_cern_htcondorce_jobstate == "
-                    "'ch.cern.HTCondorCE-JobState'"
+                    "entity.labels.ch_cern_htcondorce_jobstate == 'ch.cern.HTCondorCE-JobState'",
                 ],
-                'splay': False,
-                'splay_coverage': 0
+                "splay": False,
+                "splay_coverage": 0,
             },
-            'round_robin': False,
-            'duration': 17.584724169,
-            'executed': 1704878172,
-            'history': [
-                {'status': 0, 'executed': 1704856572},
-                {'status': 0, 'executed': 1704856573}
+            "round_robin": False,
+            "duration": 17.584724169,
+            "executed": 1704878172,
+            "history": [
+                {"status": 0, "executed": 1704856572},
+                {"status": 0, "executed": 1704856573},
             ],
-            'issued': 1704878171,
-            'output':
-                "OK - Job was successfully submitted (93770287)\n"
-                "=== Credentials:\nx509:\n/DC=EU/DC=EGI/C=HR/O=Robots/O=SRCE/"
-                "CN=Robot:argo-egi@cro-ngi.hr/CN=158209419\r\n"
-                "/ops/Role=NULL/Capability=NULL\r\n\n",
-            'state': 'passing',
-            'status': 0,
-            'total_state_change': 0,
-            'last_ok': 1704878172,
-            'occurrences': 88,
-            'occurrences_watermark': 88,
-            'output_metric_format': '',
-            'output_metric_handlers': None,
-            'env_vars': None,
-            'metadata': {
-                'name': 'ch.cern.HTCondorCE-JobState',
-                'namespace': 'default',
-                'annotations': {'attempts': '2'},
-                "labels": {"tenants": "ni4os"}
+            "issued": 1704878171,
+            "output": "OK - Job was successfully submitted (93770287)\n"
+            "=== Credentials:\nx509:\n/DC=EU/DC=EGI/C=HR/O=Robots/O=SRCE/"
+            "CN=Robot:argo-egi@cro-ngi.hr/CN=158209419\r\n"
+            "/ops/Role=NULL/Capability=NULL\r\n\n",
+            "state": "passing",
+            "status": 0,
+            "total_state_change": 0,
+            "last_ok": 1704878172,
+            "occurrences": 88,
+            "occurrences_watermark": 88,
+            "output_metric_format": "",
+            "output_metric_handlers": None,
+            "env_vars": None,
+            "metadata": {
+                "name": "ch.cern.HTCondorCE-JobState",
+                "namespace": "default",
+                "annotations": {"attempts": "2"},
+                "labels": {"tenants": "ni4os"},
             },
-            'secrets': None,
-            'is_silenced': False,
-            'scheduler': '',
-            'processed_by': 'sensu-agent-egi-htcondor-devel.cro-ngi',
-            'pipelines': [{
-                'name': 'hard_state',
-                'type': 'Pipeline',
-                'api_version': 'core/v2'
-            }]
+            "secrets": None,
+            "is_silenced": False,
+            "scheduler": "",
+            "processed_by": "sensu-agent-egi-htcondor-devel.cro-ngi",
+            "pipelines": [{"name": "hard_state", "type": "Pipeline", "api_version": "core/v2"}],
         },
-        'entity': {
-            'entity_class': 'proxy',
-            'subscriptions': None,
-            'last_seen': 0,
-            'deregister': False,
-            'deregistration': {},
-            'metadata': {
-                'name': 'org.opensciencegrid.htcondorce__ce503.cern.ch',
-                'namespace': 'default',
-                'labels': {
-                    'argo_certificate_validity_htcondorce':
-                        'argo.certificate.validity-htcondorce',
-                    'ch_cern_htcondorce_jobstate':
-                        'ch.cern.HTCondorCE-JobState',
-                    'ch_cern_htcondorce_jobstate_pool': 'ce503.cern.ch:9619',
-                    'ch_cern_htcondorce_jobstate_resource':
-                        'condor-ce://ce503.cern.ch/ce503.cern.ch/nopbs/noqueue',
-                    'ch_cern_htcondorce_jobstate_schedd': 'ce503.cern.ch',
-                    'ch_cern_htcondorce_jobsubmit':
-                        'ch.cern.HTCondorCE-JobSubmit',
-                    'hostname': 'ce503.cern.ch',
-                    'service': 'org.opensciencegrid.htcondorce',
-                    'site': 'CERN-PROD',
-                    'site_bdii': 'site-bdii.cern.ch',
-                    "tenants": "ni4os"
-                }
+        "entity": {
+            "entity_class": "proxy",
+            "subscriptions": None,
+            "last_seen": 0,
+            "deregister": False,
+            "deregistration": {},
+            "metadata": {
+                "name": "org.opensciencegrid.htcondorce__ce503.cern.ch",
+                "namespace": "default",
+                "labels": {
+                    "argo_certificate_validity_htcondorce": "argo.certificate.validity-htcondorce",
+                    "ch_cern_htcondorce_jobstate": "ch.cern.HTCondorCE-JobState",
+                    "ch_cern_htcondorce_jobstate_pool": "ce503.cern.ch:9619",
+                    "ch_cern_htcondorce_jobstate_resource": "condor-ce://ce503.cern.ch/ce503.cern.ch/nopbs/noqueue",
+                    "ch_cern_htcondorce_jobstate_schedd": "ce503.cern.ch",
+                    "ch_cern_htcondorce_jobsubmit": "ch.cern.HTCondorCE-JobSubmit",
+                    "hostname": "ce503.cern.ch",
+                    "service": "org.opensciencegrid.htcondorce",
+                    "site": "CERN-PROD",
+                    "site_bdii": "site-bdii.cern.ch",
+                    "tenants": "ni4os",
+                },
             },
-            'sensu_agent_version': ''
+            "sensu_agent_version": "",
         },
-        'id': 'xxxx',
-        'metadata': {'namespace': 'default'},
-        'pipelines': [{
-            'name': 'hard_state', 'type': 'Pipeline', 'api_version': 'core/v2'
-        }],
-        'sequence': 17331,
-        'timestamp': 1704878189
-    }, {
-        'check': {
-            'handlers': ['publisher-handler'],
-            'high_flap_threshold': 0,
-            'interval': 0,
-            'low_flap_threshold': 0,
-            'publish': False,
-            'runtime_assets': None,
-            'subscriptions': [],
-            'proxy_entity_name': '',
-            'check_hooks': None,
-            'stdin': False,
-            'subdue': None,
-            'ttl': 0,
-            'timeout': 0,
-            'round_robin': False,
-            'executed': 0,
-            'history': [
-                {'status': 3, 'executed': 0},
-                {'status': 3, 'executed': 0},
-                {'status': 0, 'executed': 0}
+        "id": "xxxx",
+        "metadata": {"namespace": "default"},
+        "pipelines": [{"name": "hard_state", "type": "Pipeline", "api_version": "core/v2"}],
+        "sequence": 17331,
+        "timestamp": 1704878189,
+    },
+    {
+        "check": {
+            "handlers": ["publisher-handler"],
+            "high_flap_threshold": 0,
+            "interval": 0,
+            "low_flap_threshold": 0,
+            "publish": False,
+            "runtime_assets": None,
+            "subscriptions": [],
+            "proxy_entity_name": "",
+            "check_hooks": None,
+            "stdin": False,
+            "subdue": None,
+            "ttl": 0,
+            "timeout": 0,
+            "round_robin": False,
+            "executed": 0,
+            "history": [
+                {"status": 3, "executed": 0},
+                {"status": 3, "executed": 0},
+                {"status": 0, "executed": 0},
             ],
-            'issued': 0,
-            'output':
-                'OK - Job successfully completed\\n=== ETF job log:\\nTimeout '
-                'limits configured were:\\n=== Credentials:\\nx509:\\n'
-                '/DC=EU/DC=EGI/C=HR/O=Robots/O=SRCE/CN=Robot:argo-egi@'
-                'cro-ngi.hr/CN=2102436855\n\\n/ops/Role=NULL/Capability=NULL\n',
-            'state': 'passing',
-            'status': 0,
-            'total_state_change': 0,
-            'last_ok': 0,
-            'occurrences': 3,
-            'occurrences_watermark': 3,
-            'output_metric_format': '',
-            'output_metric_handlers': None,
-            'env_vars': None,
-            'metadata': {
-                'name': 'ch.cern.HTCondorCE-JobSubmit',
-                'namespace': 'default',
-                'created_by': 'admin',
-                "labels": {"tenants": "ni4os"}
+            "issued": 0,
+            "output": "OK - Job successfully completed\\n=== ETF job log:\\nTimeout "
+            "limits configured were:\\n=== Credentials:\\nx509:\\n"
+            "/DC=EU/DC=EGI/C=HR/O=Robots/O=SRCE/CN=Robot:argo-egi@"
+            "cro-ngi.hr/CN=2102436855\n\\n/ops/Role=NULL/Capability=NULL\n",
+            "state": "passing",
+            "status": 0,
+            "total_state_change": 0,
+            "last_ok": 0,
+            "occurrences": 3,
+            "occurrences_watermark": 3,
+            "output_metric_format": "",
+            "output_metric_handlers": None,
+            "env_vars": None,
+            "metadata": {
+                "name": "ch.cern.HTCondorCE-JobSubmit",
+                "namespace": "default",
+                "created_by": "admin",
+                "labels": {"tenants": "ni4os"},
             },
-            'secrets': None,
-            'is_silenced': False,
-            'scheduler': '',
-            'pipelines': []
+            "secrets": None,
+            "is_silenced": False,
+            "scheduler": "",
+            "pipelines": [],
         },
-        'entity': {
-            'entity_class': 'proxy',
-            'subscriptions': None,
-            'last_seen': 0,
-            'deregister': False,
-            'deregistration': {},
-            'metadata': {
-                'name': 'org.opensciencegrid.htcondorce__ce503.cern.ch',
-                'namespace': 'default',
-                'labels': {
-                    'argo_certificate_validity_htcondorce':
-                        'argo.certificate.validity-htcondorce',
-                    'ch_cern_htcondorce_jobstate':
-                        'ch.cern.HTCondorCE-JobState',
-                    'ch_cern_htcondorce_jobstate_pool': 'ce503.cern.ch:9619',
-                    'ch_cern_htcondorce_jobstate_resource':
-                        'condor-ce://ce503.cern.ch/ce503.cern.ch/nopbs/noqueue',
-                    'ch_cern_htcondorce_jobstate_schedd': 'ce503.cern.ch',
-                    'ch_cern_htcondorce_jobsubmit':
-                        'ch.cern.HTCondorCE-JobSubmit',
-                    'hostname': 'ce503.cern.ch',
-                    'service': 'org.opensciencegrid.htcondorce',
-                    'site': 'CERN-PROD',
-                    'site_bdii': 'site-bdii.cern.ch',
-                    "tenants": "ni4os"
-                }
+        "entity": {
+            "entity_class": "proxy",
+            "subscriptions": None,
+            "last_seen": 0,
+            "deregister": False,
+            "deregistration": {},
+            "metadata": {
+                "name": "org.opensciencegrid.htcondorce__ce503.cern.ch",
+                "namespace": "default",
+                "labels": {
+                    "argo_certificate_validity_htcondorce": "argo.certificate.validity-htcondorce",
+                    "ch_cern_htcondorce_jobstate": "ch.cern.HTCondorCE-JobState",
+                    "ch_cern_htcondorce_jobstate_pool": "ce503.cern.ch:9619",
+                    "ch_cern_htcondorce_jobstate_resource": "condor-ce://ce503.cern.ch/ce503.cern.ch/nopbs/noqueue",
+                    "ch_cern_htcondorce_jobstate_schedd": "ce503.cern.ch",
+                    "ch_cern_htcondorce_jobsubmit": "ch.cern.HTCondorCE-JobSubmit",
+                    "hostname": "ce503.cern.ch",
+                    "service": "org.opensciencegrid.htcondorce",
+                    "site": "CERN-PROD",
+                    "site_bdii": "site-bdii.cern.ch",
+                    "tenants": "ni4os",
+                },
             },
-            'sensu_agent_version': ''
+            "sensu_agent_version": "",
         },
-        'id': 'xxxx',
-        'metadata': {'created_by': 'admin'},
-        'pipelines': None,
-        'sequence': 0,
-        'timestamp': 1704860185
-    }
+        "id": "xxxx",
+        "metadata": {"created_by": "admin"},
+        "pipelines": None,
+        "sequence": 0,
+        "timestamp": 1704860185,
+    },
 ]
 
 mock_events_ctl_with_unknowns = [
     {
-        'check': {
-            'command': '/usr/lib64/nagios/plugins/check_aris -H '
-                       'hostname1.example.com -t 120 --if-no-queues OK '
-                       '--cluster-test arc5-test --if-no-clusters UNKNOWN',
-            'handlers': [],
-            'high_flap_threshold': 0,
-            'interval': 3600,
-            'low_flap_threshold': 0,
-            'publish': True,
-            'runtime_assets': None,
-            'subscriptions': [
-                "entity:sensu-agent1"
-            ],
-            'proxy_entity_name': 'ARC-CE__hostname1.example.com',
-            'check_hooks': None,
-            'stdin': False,
-            'subdue': None,
-            'ttl': 0,
-            'timeout': 900,
-            'proxy_requests': {
-                'entity_attributes': [
+        "check": {
+            "command": "/usr/lib64/nagios/plugins/check_aris -H "
+            "hostname1.example.com -t 120 --if-no-queues OK "
+            "--cluster-test arc5-test --if-no-clusters UNKNOWN",
+            "handlers": [],
+            "high_flap_threshold": 0,
+            "interval": 3600,
+            "low_flap_threshold": 0,
+            "publish": True,
+            "runtime_assets": None,
+            "subscriptions": ["entity:sensu-agent1"],
+            "proxy_entity_name": "ARC-CE__hostname1.example.com",
+            "check_hooks": None,
+            "stdin": False,
+            "subdue": None,
+            "ttl": 0,
+            "timeout": 900,
+            "proxy_requests": {
+                "entity_attributes": [
                     "entity.entity_class == 'proxy'",
-                    "entity.labels.eu_egi_sec_arc_ce_5 == 'eu.egi.sec.ARC-CE-5'"
+                    "entity.labels.eu_egi_sec_arc_ce_5 == 'eu.egi.sec.ARC-CE-5'",
                 ],
-                'splay': False,
-                'splay_coverage': 0
+                "splay": False,
+                "splay_coverage": 0,
             },
-            'round_robin': False,
-            'duration': 1.096049347,
-            'executed': 1710771245,
-            'history': [
-                {'status': 0, 'executed': 1710717244},
-                {'status': 0, 'executed': 1710720844},
-                {'status': 0, 'executed': 1710724444},
-                {'status': 0, 'executed': 1710728044}
+            "round_robin": False,
+            "duration": 1.096049347,
+            "executed": 1710771245,
+            "history": [
+                {"status": 0, "executed": 1710717244},
+                {"status": 0, "executed": 1710720844},
+                {"status": 0, "executed": 1710724444},
+                {"status": 0, "executed": 1710728044},
             ],
-            'issued': 1710771245,
-            'output': '1 cluster (nordugrid-arc-6.15.1), 3 queues (active, '
-                      'active, active)\n',
-            'state': 'passing',
-            'status': 0,
-            'total_state_change': 0,
-            'last_ok': 1710771245,
-            'occurrences': 1940,
-            'occurrences_watermark': 1940,
-            'output_metric_format': '',
-            'output_metric_handlers': None,
-            'env_vars': None,
-            'metadata': {
-                'name': 'eu.egi.sec.ARC-CE-5',
-                'namespace': 'default',
-                'annotations': {'attempts': '2'},
-                "labels": {"tenants": "ni4os"}
+            "issued": 1710771245,
+            "output": "1 cluster (nordugrid-arc-6.15.1), 3 queues (active, active, active)\n",
+            "state": "passing",
+            "status": 0,
+            "total_state_change": 0,
+            "last_ok": 1710771245,
+            "occurrences": 1940,
+            "occurrences_watermark": 1940,
+            "output_metric_format": "",
+            "output_metric_handlers": None,
+            "env_vars": None,
+            "metadata": {
+                "name": "eu.egi.sec.ARC-CE-5",
+                "namespace": "default",
+                "annotations": {"attempts": "2"},
+                "labels": {"tenants": "ni4os"},
             },
-            'secrets': None,
-            'is_silenced': False,
-            'scheduler': '',
-            'processed_by': 'sensu-agent1',
-            'pipelines': [{
-                'name': 'hard_state',
-                'type': 'Pipeline',
-                'api_version': 'core/v2'
-            }]},
-        'entity': {
-            'entity_class': 'proxy',
-            'subscriptions': None,
-            'last_seen': 0,
-            'deregister': False,
-            'deregistration': {},
-            'metadata': {
-                'name': 'ARC-CE__hostname1.example.com',
-                'namespace': 'default',
-                'labels': {
-                    'eu_egi_sec_arc_ce_5': 'eu.egi.sec.ARC-CE-5',
-                    'hostname': 'hostname1.example.com',
-                    'org_nordugrid_arc_ce_aris': 'org.nordugrid.ARC-CE-ARIS',
-                    'org_nordugrid_arc_ce_igtf': 'org.nordugrid.ARC-CE-IGTF',
-                    'org_nordugrid_arc_ce_result':
-                        'org.nordugrid.ARC-CE-result',
-                    'org_nordugrid_arc_ce_srm': 'org.nordugrid.ARC-CE-srm',
-                    'org_nordugrid_arc_ce_srm_result':
-                        'org.nordugrid.ARC-CE-SRM-result',
-                    'org_nordugrid_arc_ce_srm_submit':
-                        'org.nordugrid.ARC-CE-SRM-submit',
-                    'org_nordugrid_arc_ce_submit':
-                        'org.nordugrid.ARC-CE-submit',
-                    'org_nordugrid_arc_ce_sw_csh':
-                        'org.nordugrid.ARC-CE-sw-csh',
-                    'org_nordugrid_arc_ce_sw_gcc':
-                        'org.nordugrid.ARC-CE-sw-gcc',
-                    'org_nordugrid_arc_ce_sw_perl':
-                        'org.nordugrid.ARC-CE-sw-perl',
-                    'org_nordugrid_arc_ce_sw_python':
-                        'org.nordugrid.ARC-CE-sw-python',
-                    'service': 'ARC-CE',
-                    'site': 'SITE1',
-                    "tenants": "ni4os"
-                }
-            },
-            'sensu_agent_version': ''
+            "secrets": None,
+            "is_silenced": False,
+            "scheduler": "",
+            "processed_by": "sensu-agent1",
+            "pipelines": [{"name": "hard_state", "type": "Pipeline", "api_version": "core/v2"}],
         },
-        'id': 'xxxxx',
-        'metadata': {'namespace': 'default'},
-        'pipelines': [{
-            'name': 'hard_state',
-            'type': 'Pipeline',
-            'api_version': 'core/v2'
-        }],
-        'sequence': 74037,
-        'timestamp': 1710771246
-    }, {
-        'check': {
-            'command': '/usr/lib64/nagios/plugins/check_aris -H '
-                       'hostname1.example.com -t 60 --queue-test '
-                       'dist-queue-active',
-            'handlers': [],
-            'high_flap_threshold': 0,
-            'interval': 1800,
-            'low_flap_threshold': 0,
-            'publish': True,
-            'runtime_assets': None,
-            'subscriptions': [
-                "entity:sensu-agent1"
-            ],
-            'proxy_entity_name': 'ARC-CE__hostname1.example.com',
-            'check_hooks': None,
-            'stdin': False,
-            'subdue': None,
-            'ttl': 0,
-            'timeout': 900,
-            'proxy_requests': {
-                'entity_attributes': [
+        "entity": {
+            "entity_class": "proxy",
+            "subscriptions": None,
+            "last_seen": 0,
+            "deregister": False,
+            "deregistration": {},
+            "metadata": {
+                "name": "ARC-CE__hostname1.example.com",
+                "namespace": "default",
+                "labels": {
+                    "eu_egi_sec_arc_ce_5": "eu.egi.sec.ARC-CE-5",
+                    "hostname": "hostname1.example.com",
+                    "org_nordugrid_arc_ce_aris": "org.nordugrid.ARC-CE-ARIS",
+                    "org_nordugrid_arc_ce_igtf": "org.nordugrid.ARC-CE-IGTF",
+                    "org_nordugrid_arc_ce_result": "org.nordugrid.ARC-CE-result",
+                    "org_nordugrid_arc_ce_srm": "org.nordugrid.ARC-CE-srm",
+                    "org_nordugrid_arc_ce_srm_result": "org.nordugrid.ARC-CE-SRM-result",
+                    "org_nordugrid_arc_ce_srm_submit": "org.nordugrid.ARC-CE-SRM-submit",
+                    "org_nordugrid_arc_ce_submit": "org.nordugrid.ARC-CE-submit",
+                    "org_nordugrid_arc_ce_sw_csh": "org.nordugrid.ARC-CE-sw-csh",
+                    "org_nordugrid_arc_ce_sw_gcc": "org.nordugrid.ARC-CE-sw-gcc",
+                    "org_nordugrid_arc_ce_sw_perl": "org.nordugrid.ARC-CE-sw-perl",
+                    "org_nordugrid_arc_ce_sw_python": "org.nordugrid.ARC-CE-sw-python",
+                    "service": "ARC-CE",
+                    "site": "SITE1",
+                    "tenants": "ni4os",
+                },
+            },
+            "sensu_agent_version": "",
+        },
+        "id": "xxxxx",
+        "metadata": {"namespace": "default"},
+        "pipelines": [{"name": "hard_state", "type": "Pipeline", "api_version": "core/v2"}],
+        "sequence": 74037,
+        "timestamp": 1710771246,
+    },
+    {
+        "check": {
+            "command": "/usr/lib64/nagios/plugins/check_aris -H "
+            "hostname1.example.com -t 60 --queue-test "
+            "dist-queue-active",
+            "handlers": [],
+            "high_flap_threshold": 0,
+            "interval": 1800,
+            "low_flap_threshold": 0,
+            "publish": True,
+            "runtime_assets": None,
+            "subscriptions": ["entity:sensu-agent1"],
+            "proxy_entity_name": "ARC-CE__hostname1.example.com",
+            "check_hooks": None,
+            "stdin": False,
+            "subdue": None,
+            "ttl": 0,
+            "timeout": 900,
+            "proxy_requests": {
+                "entity_attributes": [
                     "entity.entity_class == 'proxy'",
-                    "entity.labels.org_nordugrid_arc_ce_aris == "
-                    "'org.nordugrid.ARC-CE-ARIS'"
+                    "entity.labels.org_nordugrid_arc_ce_aris == 'org.nordugrid.ARC-CE-ARIS'",
                 ],
-                'splay': False,
-                'splay_coverage': 0
+                "splay": False,
+                "splay_coverage": 0,
             },
-            'round_robin': False,
-            'duration': 1.171800921,
-            'executed': 1710770788,
-            'history': [
-                {'status': 0, 'executed': 1710752788},
-                {'status': 0, 'executed': 1710752788},
-                {'status': 0, 'executed': 1710754588},
-                {'status': 0, 'executed': 1710754588},
-                {'status': 0, 'executed': 1710756388}
+            "round_robin": False,
+            "duration": 1.171800921,
+            "executed": 1710770788,
+            "history": [
+                {"status": 0, "executed": 1710752788},
+                {"status": 0, "executed": 1710752788},
+                {"status": 0, "executed": 1710754588},
+                {"status": 0, "executed": 1710754588},
+                {"status": 0, "executed": 1710756388},
             ],
-            'issued': 1710770788,
-            'output': '1 cluster (nordugrid-arc-6.15.1), 3 queues (active, '
-                      'active, active)\n',
-            'state': 'passing',
-            'status': 0,
-            'total_state_change': 0,
-            'last_ok': 1710770788,
-            'occurrences': 4220,
-            'occurrences_watermark': 4220,
-            'output_metric_format': '',
-            'output_metric_handlers': None,
-            'env_vars': None,
-            'metadata': {
-                'name': 'org.nordugrid.ARC-CE-ARIS',
-                'namespace': 'default',
-                'annotations': {'attempts': '3'},
-                "labels": {"tenants": "ni4os"}
+            "issued": 1710770788,
+            "output": "1 cluster (nordugrid-arc-6.15.1), 3 queues (active, active, active)\n",
+            "state": "passing",
+            "status": 0,
+            "total_state_change": 0,
+            "last_ok": 1710770788,
+            "occurrences": 4220,
+            "occurrences_watermark": 4220,
+            "output_metric_format": "",
+            "output_metric_handlers": None,
+            "env_vars": None,
+            "metadata": {
+                "name": "org.nordugrid.ARC-CE-ARIS",
+                "namespace": "default",
+                "annotations": {"attempts": "3"},
+                "labels": {"tenants": "ni4os"},
             },
-            'secrets': None,
-            'is_silenced': False,
-            'scheduler': '',
-            'processed_by': 'sensu-agent-1',
-            'pipelines': [{
-                'name': 'hard_state',
-                'type': 'Pipeline',
-                'api_version': 'core/v2'
-            }]
+            "secrets": None,
+            "is_silenced": False,
+            "scheduler": "",
+            "processed_by": "sensu-agent-1",
+            "pipelines": [{"name": "hard_state", "type": "Pipeline", "api_version": "core/v2"}],
         },
-        'entity': {
-            'entity_class': 'proxy',
-            'subscriptions': None,
-            'last_seen': 0,
-            'deregister': False,
-            'deregistration': {},
-            'metadata': {
-                'name': 'ARC-CE__hostname1.example.com',
-                'namespace': 'default',
-                'labels': {
-                    'eu_egi_sec_arc_ce_5': 'eu.egi.sec.ARC-CE-5',
-                    'hostname': 'hostname1.example.com',
-                    'org_nordugrid_arc_ce_aris': 'org.nordugrid.ARC-CE-ARIS',
-                    'org_nordugrid_arc_ce_igtf': 'org.nordugrid.ARC-CE-IGTF',
-                    'org_nordugrid_arc_ce_result':
-                        'org.nordugrid.ARC-CE-result',
-                    'org_nordugrid_arc_ce_srm': 'org.nordugrid.ARC-CE-srm',
-                    'org_nordugrid_arc_ce_srm_result':
-                        'org.nordugrid.ARC-CE-SRM-result',
-                    'org_nordugrid_arc_ce_srm_submit':
-                        'org.nordugrid.ARC-CE-SRM-submit',
-                    'org_nordugrid_arc_ce_submit':
-                        'org.nordugrid.ARC-CE-submit',
-                    'org_nordugrid_arc_ce_sw_csh':
-                        'org.nordugrid.ARC-CE-sw-csh',
-                    'org_nordugrid_arc_ce_sw_gcc':
-                        'org.nordugrid.ARC-CE-sw-gcc',
-                    'org_nordugrid_arc_ce_sw_perl':
-                        'org.nordugrid.ARC-CE-sw-perl',
-                    'org_nordugrid_arc_ce_sw_python':
-                        'org.nordugrid.ARC-CE-sw-python',
-                    'service': 'ARC-CE',
-                    'site': 'SITE1',
-                    "tenants": "ni4os"
-                }
+        "entity": {
+            "entity_class": "proxy",
+            "subscriptions": None,
+            "last_seen": 0,
+            "deregister": False,
+            "deregistration": {},
+            "metadata": {
+                "name": "ARC-CE__hostname1.example.com",
+                "namespace": "default",
+                "labels": {
+                    "eu_egi_sec_arc_ce_5": "eu.egi.sec.ARC-CE-5",
+                    "hostname": "hostname1.example.com",
+                    "org_nordugrid_arc_ce_aris": "org.nordugrid.ARC-CE-ARIS",
+                    "org_nordugrid_arc_ce_igtf": "org.nordugrid.ARC-CE-IGTF",
+                    "org_nordugrid_arc_ce_result": "org.nordugrid.ARC-CE-result",
+                    "org_nordugrid_arc_ce_srm": "org.nordugrid.ARC-CE-srm",
+                    "org_nordugrid_arc_ce_srm_result": "org.nordugrid.ARC-CE-SRM-result",
+                    "org_nordugrid_arc_ce_srm_submit": "org.nordugrid.ARC-CE-SRM-submit",
+                    "org_nordugrid_arc_ce_submit": "org.nordugrid.ARC-CE-submit",
+                    "org_nordugrid_arc_ce_sw_csh": "org.nordugrid.ARC-CE-sw-csh",
+                    "org_nordugrid_arc_ce_sw_gcc": "org.nordugrid.ARC-CE-sw-gcc",
+                    "org_nordugrid_arc_ce_sw_perl": "org.nordugrid.ARC-CE-sw-perl",
+                    "org_nordugrid_arc_ce_sw_python": "org.nordugrid.ARC-CE-sw-python",
+                    "service": "ARC-CE",
+                    "site": "SITE1",
+                    "tenants": "ni4os",
+                },
             },
-            'sensu_agent_version': ''
+            "sensu_agent_version": "",
         },
-        'id': 'xxxxx',
-        'metadata': {'namespace': 'default'},
-        'pipelines': [{
-            'name': 'hard_state',
-            'type': 'Pipeline',
-            'api_version': 'core/v2'
-        }],
-        'sequence': 150531,
-        'timestamp': 1710770789
-    }, {
-        'check': {
-            'handlers': [],
-            'high_flap_threshold': 0,
-            'interval': 0,
-            'low_flap_threshold': 0,
-            'publish': False,
-            'runtime_assets': None,
-            'subscriptions': [],
-            'proxy_entity_name': '',
-            'check_hooks': None,
-            'stdin': False,
-            'subdue': None,
-            'ttl': 0,
-            'timeout': 0,
-            'round_robin': False,
-            'executed': 0,
-            'history': [
-                {'status': 3, 'executed': 0},
-                {'status': 3, 'executed': 0},
-                {'status': 3, 'executed': 0},
-                {'status': 3, 'executed': 0},
-                {'status': 3, 'executed': 0}
+        "id": "xxxxx",
+        "metadata": {"namespace": "default"},
+        "pipelines": [{"name": "hard_state", "type": "Pipeline", "api_version": "core/v2"}],
+        "sequence": 150531,
+        "timestamp": 1710770789,
+    },
+    {
+        "check": {
+            "handlers": [],
+            "high_flap_threshold": 0,
+            "interval": 0,
+            "low_flap_threshold": 0,
+            "publish": False,
+            "runtime_assets": None,
+            "subscriptions": [],
+            "proxy_entity_name": "",
+            "check_hooks": None,
+            "stdin": False,
+            "subdue": None,
+            "ttl": 0,
+            "timeout": 0,
+            "round_robin": False,
+            "executed": 0,
+            "history": [
+                {"status": 3, "executed": 0},
+                {"status": 3, "executed": 0},
+                {"status": 3, "executed": 0},
+                {"status": 3, "executed": 0},
+                {"status": 3, "executed": 0},
             ],
-            'issued': 0,
-            'output': 'Missing directory $X509_CERT_DIR (/etc/grid-security/'
-                      'certificates).',
-            'state': 'failing',
-            'status': 127,
-            'total_state_change': 0,
-            'last_ok': 0,
-            'occurrences': 615,
-            'occurrences_watermark': 615,
-            'output_metric_format': '',
-            'output_metric_handlers': None,
-            'env_vars': None,
-            'metadata': {
-                'name': 'org.nordugrid.ARC-CE-IGTF',
-                'namespace': 'default',
-                'created_by': 'admin',
-                "labels": {"tenants": "ni4os"}
+            "issued": 0,
+            "output": "Missing directory $X509_CERT_DIR (/etc/grid-security/certificates).",
+            "state": "failing",
+            "status": 127,
+            "total_state_change": 0,
+            "last_ok": 0,
+            "occurrences": 615,
+            "occurrences_watermark": 615,
+            "output_metric_format": "",
+            "output_metric_handlers": None,
+            "env_vars": None,
+            "metadata": {
+                "name": "org.nordugrid.ARC-CE-IGTF",
+                "namespace": "default",
+                "created_by": "admin",
+                "labels": {"tenants": "ni4os"},
             },
-            'secrets': None,
-            'is_silenced': False,
-            'scheduler': '',
-            'pipelines': [{
-                'name': 'hard_state',
-                'type': 'Pipeline',
-                'api_version': 'core/v2'
-            }]
+            "secrets": None,
+            "is_silenced": False,
+            "scheduler": "",
+            "pipelines": [{"name": "hard_state", "type": "Pipeline", "api_version": "core/v2"}],
         },
-        'entity': {
-            'entity_class': 'proxy',
-            'subscriptions': None,
-            'last_seen': 0,
-            'deregister': False,
-            'deregistration': {},
-            'metadata': {
-                'name': 'ARC-CE__hostname2.example.com',
-                'namespace': 'default',
-                'labels': {
-                    'eu_egi_sec_arc_ce_5': 'eu.egi.sec.ARC-CE-5',
-                    'hostname': 'hostname2.example.com',
-                    'org_nordugrid_arc_ce_aris': 'org.nordugrid.ARC-CE-ARIS',
-                    'org_nordugrid_arc_ce_igtf': 'org.nordugrid.ARC-CE-IGTF',
-                    'org_nordugrid_arc_ce_result':
-                        'org.nordugrid.ARC-CE-result',
-                    'org_nordugrid_arc_ce_srm': 'org.nordugrid.ARC-CE-srm',
-                    'org_nordugrid_arc_ce_srm_result':
-                        'org.nordugrid.ARC-CE-SRM-result',
-                    'org_nordugrid_arc_ce_srm_submit':
-                        'org.nordugrid.ARC-CE-SRM-submit',
-                    'org_nordugrid_arc_ce_submit':
-                        'org.nordugrid.ARC-CE-submit',
-                    'org_nordugrid_arc_ce_sw_csh':
-                        'org.nordugrid.ARC-CE-sw-csh',
-                    'org_nordugrid_arc_ce_sw_gcc':
-                        'org.nordugrid.ARC-CE-sw-gcc',
-                    'org_nordugrid_arc_ce_sw_perl':
-                        'org.nordugrid.ARC-CE-sw-perl',
-                    'org_nordugrid_arc_ce_sw_python':
-                        'org.nordugrid.ARC-CE-sw-python',
-                    'service': 'ARC-CE',
-                    'site': 'SITE2',
-                    "tenants": "ni4os"
-                }
+        "entity": {
+            "entity_class": "proxy",
+            "subscriptions": None,
+            "last_seen": 0,
+            "deregister": False,
+            "deregistration": {},
+            "metadata": {
+                "name": "ARC-CE__hostname2.example.com",
+                "namespace": "default",
+                "labels": {
+                    "eu_egi_sec_arc_ce_5": "eu.egi.sec.ARC-CE-5",
+                    "hostname": "hostname2.example.com",
+                    "org_nordugrid_arc_ce_aris": "org.nordugrid.ARC-CE-ARIS",
+                    "org_nordugrid_arc_ce_igtf": "org.nordugrid.ARC-CE-IGTF",
+                    "org_nordugrid_arc_ce_result": "org.nordugrid.ARC-CE-result",
+                    "org_nordugrid_arc_ce_srm": "org.nordugrid.ARC-CE-srm",
+                    "org_nordugrid_arc_ce_srm_result": "org.nordugrid.ARC-CE-SRM-result",
+                    "org_nordugrid_arc_ce_srm_submit": "org.nordugrid.ARC-CE-SRM-submit",
+                    "org_nordugrid_arc_ce_submit": "org.nordugrid.ARC-CE-submit",
+                    "org_nordugrid_arc_ce_sw_csh": "org.nordugrid.ARC-CE-sw-csh",
+                    "org_nordugrid_arc_ce_sw_gcc": "org.nordugrid.ARC-CE-sw-gcc",
+                    "org_nordugrid_arc_ce_sw_perl": "org.nordugrid.ARC-CE-sw-perl",
+                    "org_nordugrid_arc_ce_sw_python": "org.nordugrid.ARC-CE-sw-python",
+                    "service": "ARC-CE",
+                    "site": "SITE2",
+                    "tenants": "ni4os",
+                },
             },
-            'sensu_agent_version': ''
+            "sensu_agent_version": "",
         },
-        'id': 'xxxxx',
-        'metadata': {'created_by': 'admin'},
-        'pipelines': None,
-        'sequence': 0,
-        'timestamp': 1710712879
-    }, {
-        'check': {
-            'handlers': [],
-            'high_flap_threshold': 0,
-            'interval': 0,
-            'low_flap_threshold': 0,
-            'publish': False,
-            'runtime_assets': None,
-            'subscriptions': [],
-            'proxy_entity_name': '',
-            'check_hooks': None,
-            'stdin': False,
-            'subdue': None,
-            'ttl': 0,
-            'timeout': 0,
-            'round_robin': False,
-            'executed': 0,
-            'history': [
-                {'status': 3, 'executed': 0},
-                {'status': 3, 'executed': 0},
-                {'status': 3, 'executed': 0},
-                {'status': 3, 'executed': 0},
-                {'status': 3, 'executed': 0}
+        "id": "xxxxx",
+        "metadata": {"created_by": "admin"},
+        "pipelines": None,
+        "sequence": 0,
+        "timestamp": 1710712879,
+    },
+    {
+        "check": {
+            "handlers": [],
+            "high_flap_threshold": 0,
+            "interval": 0,
+            "low_flap_threshold": 0,
+            "publish": False,
+            "runtime_assets": None,
+            "subscriptions": [],
+            "proxy_entity_name": "",
+            "check_hooks": None,
+            "stdin": False,
+            "subdue": None,
+            "ttl": 0,
+            "timeout": 0,
+            "round_robin": False,
+            "executed": 0,
+            "history": [
+                {"status": 3, "executed": 0},
+                {"status": 3, "executed": 0},
+                {"status": 3, "executed": 0},
+                {"status": 3, "executed": 0},
+                {"status": 3, "executed": 0},
             ],
-            'issued': 0,
-            'output': 'Missing directory $X509_CERT_DIR (/etc/grid-security/'
-                      'certificates).',
-            'state': 'failing',
-            'status': 3,
-            'total_state_change': 0,
-            'last_ok': 0,
-            'occurrences': 566,
-            'occurrences_watermark': 566,
-            'output_metric_format': '',
-            'output_metric_handlers': None,
-            'env_vars': None,
-            'metadata': {
-                'name': 'org.nordugrid.ARC-CE-IGTF',
-                'namespace': 'default',
-                'created_by': 'admin',
-                "labels": {"tenants": "ni4os"}
+            "issued": 0,
+            "output": "Missing directory $X509_CERT_DIR (/etc/grid-security/certificates).",
+            "state": "failing",
+            "status": 3,
+            "total_state_change": 0,
+            "last_ok": 0,
+            "occurrences": 566,
+            "occurrences_watermark": 566,
+            "output_metric_format": "",
+            "output_metric_handlers": None,
+            "env_vars": None,
+            "metadata": {
+                "name": "org.nordugrid.ARC-CE-IGTF",
+                "namespace": "default",
+                "created_by": "admin",
+                "labels": {"tenants": "ni4os"},
             },
-            'secrets': None,
-            'is_silenced': False,
-            'scheduler': '',
-            'pipelines': [{
-                'name': 'hard_state',
-                'type': 'Pipeline',
-                'api_version': 'core/v2'
-            }]
+            "secrets": None,
+            "is_silenced": False,
+            "scheduler": "",
+            "pipelines": [{"name": "hard_state", "type": "Pipeline", "api_version": "core/v2"}],
         },
-        'entity': {
-            'entity_class': 'proxy',
-            'subscriptions': None,
-            'last_seen': 0,
-            'deregister': False,
-            'deregistration': {},
-            'metadata': {
-                'name': 'ARC-CE__hostname2.example.com',
-                'namespace': 'default',
-                'labels': {
-                    'eu_egi_sec_arc_ce_5': 'eu.egi.sec.ARC-CE-5',
-                    'hostname': 'hostname2.example.com',
-                    'org_nordugrid_arc_ce_aris': 'org.nordugrid.ARC-CE-ARIS',
-                    'org_nordugrid_arc_ce_igtf': 'org.nordugrid.ARC-CE-IGTF',
-                    'org_nordugrid_arc_ce_result':
-                        'org.nordugrid.ARC-CE-result',
-                    'org_nordugrid_arc_ce_srm': 'org.nordugrid.ARC-CE-srm',
-                    'org_nordugrid_arc_ce_srm_result':
-                        'org.nordugrid.ARC-CE-SRM-result',
-                    'org_nordugrid_arc_ce_srm_submit':
-                        'org.nordugrid.ARC-CE-SRM-submit',
-                    'org_nordugrid_arc_ce_submit':
-                        'org.nordugrid.ARC-CE-submit',
-                    'org_nordugrid_arc_ce_sw_csh':
-                        'org.nordugrid.ARC-CE-sw-csh',
-                    'org_nordugrid_arc_ce_sw_gcc':
-                        'org.nordugrid.ARC-CE-sw-gcc',
-                    'org_nordugrid_arc_ce_sw_perl':
-                        'org.nordugrid.ARC-CE-sw-perl',
-                    'org_nordugrid_arc_ce_sw_python':
-                        'org.nordugrid.ARC-CE-sw-python',
-                    'service': 'ARC-CE',
-                    'site': 'SITE2',
-                    "tenants": "ni4os"
-                }
+        "entity": {
+            "entity_class": "proxy",
+            "subscriptions": None,
+            "last_seen": 0,
+            "deregister": False,
+            "deregistration": {},
+            "metadata": {
+                "name": "ARC-CE__hostname2.example.com",
+                "namespace": "default",
+                "labels": {
+                    "eu_egi_sec_arc_ce_5": "eu.egi.sec.ARC-CE-5",
+                    "hostname": "hostname2.example.com",
+                    "org_nordugrid_arc_ce_aris": "org.nordugrid.ARC-CE-ARIS",
+                    "org_nordugrid_arc_ce_igtf": "org.nordugrid.ARC-CE-IGTF",
+                    "org_nordugrid_arc_ce_result": "org.nordugrid.ARC-CE-result",
+                    "org_nordugrid_arc_ce_srm": "org.nordugrid.ARC-CE-srm",
+                    "org_nordugrid_arc_ce_srm_result": "org.nordugrid.ARC-CE-SRM-result",
+                    "org_nordugrid_arc_ce_srm_submit": "org.nordugrid.ARC-CE-SRM-submit",
+                    "org_nordugrid_arc_ce_submit": "org.nordugrid.ARC-CE-submit",
+                    "org_nordugrid_arc_ce_sw_csh": "org.nordugrid.ARC-CE-sw-csh",
+                    "org_nordugrid_arc_ce_sw_gcc": "org.nordugrid.ARC-CE-sw-gcc",
+                    "org_nordugrid_arc_ce_sw_perl": "org.nordugrid.ARC-CE-sw-perl",
+                    "org_nordugrid_arc_ce_sw_python": "org.nordugrid.ARC-CE-sw-python",
+                    "service": "ARC-CE",
+                    "site": "SITE2",
+                    "tenants": "ni4os",
+                },
             },
-            'sensu_agent_version': ''
+            "sensu_agent_version": "",
         },
-        'id': 'xxxxx',
-        'metadata': {'created_by': 'admin'},
-        'pipelines': None,
-        'sequence': 0,
-        'timestamp': 1710712883
-    }, {
-        'check': {
-            'handlers': [],
-            'high_flap_threshold': 0,
-            'interval': 0,
-            'low_flap_threshold': 0,
-            'publish': False,
-            'runtime_assets': None,
-            'subscriptions': [],
-            'proxy_entity_name': '',
-            'check_hooks': None,
-            'stdin': False,
-            'subdue': None,
-            'ttl': 0,
-            'timeout': 0,
-            'round_robin': False,
-            'executed': 0,
-            'history': [
-                {'status': 1, 'executed': 0},
-                {'status': 1, 'executed': 0},
-                {'status': 1, 'executed': 0}
+        "id": "xxxxx",
+        "metadata": {"created_by": "admin"},
+        "pipelines": None,
+        "sequence": 0,
+        "timestamp": 1710712883,
+    },
+    {
+        "check": {
+            "handlers": [],
+            "high_flap_threshold": 0,
+            "interval": 0,
+            "low_flap_threshold": 0,
+            "publish": False,
+            "runtime_assets": None,
+            "subscriptions": [],
+            "proxy_entity_name": "",
+            "check_hooks": None,
+            "stdin": False,
+            "subdue": None,
+            "ttl": 0,
+            "timeout": 0,
+            "round_robin": False,
+            "executed": 0,
+            "history": [
+                {"status": 1, "executed": 0},
+                {"status": 1, "executed": 0},
+                {"status": 1, "executed": 0},
             ],
-            'issued': 0,
-            'output': 'IGTF-1.128, 7 days old, found 77 CAs from 1.127',
-            'state': 'failing',
-            'status': 1,
-            'total_state_change': 0,
-            'last_ok': 0,
-            'occurrences': 31,
-            'occurrences_watermark': 31,
-            'output_metric_format': '',
-            'output_metric_handlers': None,
-            'env_vars': None,
-            'metadata': {
-                'name': 'org.nordugrid.ARC-CE-IGTF',
-                'namespace': 'default',
-                'created_by': 'admin',
-                "labels": {"tenants": "ni4os"}
+            "issued": 0,
+            "output": "IGTF-1.128, 7 days old, found 77 CAs from 1.127",
+            "state": "failing",
+            "status": 1,
+            "total_state_change": 0,
+            "last_ok": 0,
+            "occurrences": 31,
+            "occurrences_watermark": 31,
+            "output_metric_format": "",
+            "output_metric_handlers": None,
+            "env_vars": None,
+            "metadata": {
+                "name": "org.nordugrid.ARC-CE-IGTF",
+                "namespace": "default",
+                "created_by": "admin",
+                "labels": {"tenants": "ni4os"},
             },
-            'secrets': None,
-            'is_silenced': False,
-            'scheduler': '',
-            'pipelines': [{
-                'name': 'hard_state',
-                'type': 'Pipeline',
-                'api_version': 'core/v2'
-            }]
+            "secrets": None,
+            "is_silenced": False,
+            "scheduler": "",
+            "pipelines": [{"name": "hard_state", "type": "Pipeline", "api_version": "core/v2"}],
         },
-        'entity': {
-            'entity_class': 'proxy',
-            'subscriptions': None,
-            'last_seen': 0,
-            'deregister': False,
-            'deregistration': {},
-            'metadata': {
-                'name': 'ARC-CE__hostname3.example.com',
-                'namespace': 'default',
-                'labels': {
-                    'eu_egi_sec_arc_ce_5': 'eu.egi.sec.ARC-CE-5',
-                    'hostname': 'hostname3.example.com',
-                    'org_nordugrid_arc_ce_aris': 'org.nordugrid.ARC-CE-ARIS',
-                    'org_nordugrid_arc_ce_igtf': 'org.nordugrid.ARC-CE-IGTF',
-                    'org_nordugrid_arc_ce_result':
-                        'org.nordugrid.ARC-CE-result',
-                    'org_nordugrid_arc_ce_srm':
-                        'org.nordugrid.ARC-CE-srm',
-                    'org_nordugrid_arc_ce_srm_result':
-                        'org.nordugrid.ARC-CE-SRM-result',
-                    'org_nordugrid_arc_ce_srm_submit':
-                        'org.nordugrid.ARC-CE-SRM-submit',
-                    'org_nordugrid_arc_ce_submit':
-                        'org.nordugrid.ARC-CE-submit',
-                    'org_nordugrid_arc_ce_sw_csh':
-                        'org.nordugrid.ARC-CE-sw-csh',
-                    'org_nordugrid_arc_ce_sw_gcc':
-                        'org.nordugrid.ARC-CE-sw-gcc',
-                    'org_nordugrid_arc_ce_sw_perl':
-                        'org.nordugrid.ARC-CE-sw-perl',
-                    'org_nordugrid_arc_ce_sw_python':
-                        'org.nordugrid.ARC-CE-sw-python',
-                    'service': 'ARC-CE',
-                    'site': 'SITE3',
-                    "tenants": "ni4os"
-                }
+        "entity": {
+            "entity_class": "proxy",
+            "subscriptions": None,
+            "last_seen": 0,
+            "deregister": False,
+            "deregistration": {},
+            "metadata": {
+                "name": "ARC-CE__hostname3.example.com",
+                "namespace": "default",
+                "labels": {
+                    "eu_egi_sec_arc_ce_5": "eu.egi.sec.ARC-CE-5",
+                    "hostname": "hostname3.example.com",
+                    "org_nordugrid_arc_ce_aris": "org.nordugrid.ARC-CE-ARIS",
+                    "org_nordugrid_arc_ce_igtf": "org.nordugrid.ARC-CE-IGTF",
+                    "org_nordugrid_arc_ce_result": "org.nordugrid.ARC-CE-result",
+                    "org_nordugrid_arc_ce_srm": "org.nordugrid.ARC-CE-srm",
+                    "org_nordugrid_arc_ce_srm_result": "org.nordugrid.ARC-CE-SRM-result",
+                    "org_nordugrid_arc_ce_srm_submit": "org.nordugrid.ARC-CE-SRM-submit",
+                    "org_nordugrid_arc_ce_submit": "org.nordugrid.ARC-CE-submit",
+                    "org_nordugrid_arc_ce_sw_csh": "org.nordugrid.ARC-CE-sw-csh",
+                    "org_nordugrid_arc_ce_sw_gcc": "org.nordugrid.ARC-CE-sw-gcc",
+                    "org_nordugrid_arc_ce_sw_perl": "org.nordugrid.ARC-CE-sw-perl",
+                    "org_nordugrid_arc_ce_sw_python": "org.nordugrid.ARC-CE-sw-python",
+                    "service": "ARC-CE",
+                    "site": "SITE3",
+                    "tenants": "ni4os",
+                },
             },
-            'sensu_agent_version': ''
+            "sensu_agent_version": "",
         },
-        'id': 'xxxxxx',
-        'metadata': {'created_by': 'admin'},
-        'pipelines': None,
-        'sequence': 0,
-        'timestamp': 1710730711
-    }
+        "id": "xxxxxx",
+        "metadata": {"created_by": "admin"},
+        "pipelines": None,
+        "sequence": 0,
+        "timestamp": 1710730711,
+    },
 ]
 
 mock_events_ctl_multiple_tenants = [
     {
         "check": {
             "command": "/usr/lib64/nagios/plugins/check_http -H "
-                       "hostname.test.eu -t 60 --link --onredirect follow -S "
-                       "--sni -u /meh/",
+            "hostname.test.eu -t 60 --link --onredirect follow -S "
+            "--sni -u /meh/",
             "handlers": [],
             "high_flap_threshold": 0,
             "interval": 300,
             "low_flap_threshold": 0,
             "publish": True,
             "runtime_assets": None,
-            "subscriptions": [
-                "entity:sensu-agent1"
-            ],
+            "subscriptions": ["entity:sensu-agent1"],
             "proxy_entity_name": "WebService__hostname.test.eu_id_3",
             "check_hooks": None,
             "stdin": False,
@@ -3252,35 +2485,24 @@ mock_events_ctl_multiple_tenants = [
             "proxy_requests": {
                 "entity_attributes": [
                     "entity.entity_class == 'proxy'",
-                    "entity.labels.generic_http_connect == "
-                    "'generic.http.connect'"
+                    "entity.labels.generic_http_connect == 'generic.http.connect'",
                 ],
                 "splay": False,
-                "splay_coverage": 0
+                "splay_coverage": 0,
             },
             "round_robin": False,
             "duration": 0.34235994,
             "executed": 1717576405,
             "history": [
-                {
-                    "status": 0,
-                    "executed": 1717573405
-                },
-                {
-                    "status": 0,
-                    "executed": 1717573705
-                },
-                {
-                    "status": 0,
-                    "executed": 1717573705
-                }
+                {"status": 0, "executed": 1717573405},
+                {"status": 0, "executed": 1717573705},
+                {"status": 0, "executed": 1717573705},
             ],
             "issued": 1717576405,
-            "output":
-                "<A HREF=\"https://hostname.test.eu:443/meh/\" target="
-                "\"_blank\">HTTP OK: HTTP/1.1 200 OK - 9743 bytes in 0.339 "
-                "second response time </A>|time=0.339263s;;;"
-                "0.000000 size=9743B;;;0 \n",
+            "output": '<A HREF="https://hostname.test.eu:443/meh/" target='
+            '"_blank">HTTP OK: HTTP/1.1 200 OK - 9743 bytes in 0.339 '
+            "second response time </A>|time=0.339263s;;;"
+            "0.000000 size=9743B;;;0 \n",
             "state": "passing",
             "status": 0,
             "total_state_change": 0,
@@ -3293,24 +2515,14 @@ mock_events_ctl_multiple_tenants = [
             "metadata": {
                 "name": "generic.http.connect",
                 "namespace": "default",
-                "labels": {
-                    "tenants": "tenant2"
-                },
-                "annotations": {
-                    "attempts": "3"
-                }
+                "labels": {"tenants": "tenant2"},
+                "annotations": {"attempts": "3"},
             },
             "secrets": None,
             "is_silenced": False,
             "scheduler": "",
             "processed_by": "sensu-agent-poc-devel-el9.cro-ngi.hr",
-            "pipelines": [
-                {
-                    "name": "hard_state",
-                    "type": "Pipeline",
-                    "api_version": "core/v2"
-                }
-            ]
+            "pipelines": [{"name": "hard_state", "type": "Pipeline", "api_version": "core/v2"}],
         },
         "entity": {
             "entity_class": "proxy",
@@ -3322,8 +2534,7 @@ mock_events_ctl_multiple_tenants = [
                 "name": "WebService__hostname.test.eu_id_3",
                 "namespace": "default",
                 "labels": {
-                    "generic_certificate_validity":
-                        "generic.certificate.validity",
+                    "generic_certificate_validity": "generic.certificate.validity",
                     "generic_http_connect": "generic.http.connect",
                     "generic_http_connect_path": "-u /meh/",
                     "hostname": "hostname.test.eu",
@@ -3331,24 +2542,16 @@ mock_events_ctl_multiple_tenants = [
                     "service": "WebService",
                     "site": "SITE1",
                     "ssl": "-S --sni",
-                    "tenants": "tenant2"
-                }
+                    "tenants": "tenant2",
+                },
             },
-            "sensu_agent_version": ""
+            "sensu_agent_version": "",
         },
         "id": "xxxx",
-        "metadata": {
-            "namespace": "default"
-        },
-        "pipelines": [
-            {
-                "name": "hard_state",
-                "type": "Pipeline",
-                "api_version": "core/v2"
-            }
-        ],
+        "metadata": {"namespace": "default"},
+        "pipelines": [{"name": "hard_state", "type": "Pipeline", "api_version": "core/v2"}],
         "sequence": 100,
-        "timestamp": 1717576405
+        "timestamp": 1717576405,
     }
 ] + mock_events_ctl
 
@@ -3357,7 +2560,7 @@ mock_silenced = [
         "metadata": {
             "name": "entity:hostname1.example.com:generic.tcp.connect",
             "namespace": "tenant1",
-            "created_by": "admin"
+            "created_by": "admin",
         },
         "expire": -1,
         "expire_on_resolve": True,
@@ -3365,13 +2568,13 @@ mock_silenced = [
         "check": "generic.tcp.connect",
         "subscription": "entity:hostname1.example.com",
         "begin": 1718689948,
-        "expire_at": 0
+        "expire_at": 0,
     },
     {
         "metadata": {
             "name": "entity:hostname2.example.com:generic.http.connect",
             "namespace": "tenant1",
-            "created_by": "admin"
+            "created_by": "admin",
         },
         "expire": -1,
         "expire_on_resolve": True,
@@ -3379,13 +2582,13 @@ mock_silenced = [
         "check": "generic.http.connect",
         "subscription": "entity:hostname2.example.com",
         "begin": 1718689948,
-        "expire_at": 0
+        "expire_at": 0,
     },
     {
         "metadata": {
             "name": "entity:hostname2.example.com:generic.tcp.connect",
             "namespace": "tenant1",
-            "created_by": "admin"
+            "created_by": "admin",
         },
         "expire": -1,
         "expire_on_resolve": True,
@@ -3393,13 +2596,13 @@ mock_silenced = [
         "check": "generic.tcp.connect",
         "subscription": "entity:hostname2.example.com",
         "begin": 1718689948,
-        "expire_at": 0
+        "expire_at": 0,
     },
     {
         "metadata": {
             "name": "entity:hostname1.example.com:generic.certificate.validity",
             "namespace": "tenant1",
-            "created_by": "admin"
+            "created_by": "admin",
         },
         "expire": -1,
         "expire_on_resolve": True,
@@ -3407,7 +2610,7 @@ mock_silenced = [
         "check": "generic.certificate.validity",
         "subscription": "entity:hostname1.example.com",
         "begin": 1718689948,
-        "expire_at": 0
+        "expire_at": 0,
     },
 ]
 
@@ -3448,9 +2651,7 @@ def mock_sensu_request(*args, **kwargs):
 
 def mock_sensu_request_entity_not_ok_with_msg(*args, **kwargs):
     if args[0].endswith("entities"):
-        return MockResponse(
-            {"message": "Something went wrong."}, status_code=400
-        )
+        return MockResponse({"message": "Something went wrong."}, status_code=400)
 
     elif args[0].endswith("checks"):
         return MockResponse(mock_checks, status_code=200)
@@ -3481,9 +2682,7 @@ def mock_sensu_request_check_not_ok_with_msg(*args, **kwargs):
         return MockResponse(mock_entities, status_code=200)
 
     elif args[0].endswith("checks"):
-        return MockResponse(
-            {"message": "Something went wrong."}, status_code=400
-        )
+        return MockResponse({"message": "Something went wrong."}, status_code=400)
 
     elif args[0].endswith("events"):
         return MockResponse(mock_events, status_code=200)
@@ -3514,9 +2713,7 @@ def mock_sensu_request_events_not_ok_with_msg(*args, **kwargs):
         return MockResponse(mock_checks, status_code=200)
 
     elif args[0].endswith("events"):
-        return MockResponse(
-            {"message": "Something went wrong."}, status_code=400
-        )
+        return MockResponse({"message": "Something went wrong."}, status_code=400)
 
     elif args[0].endswith("namespaces"):
         return MockResponse(mock_namespaces, status_code=200)
@@ -3547,9 +2744,7 @@ def mock_sensu_request_namespaces_not_ok_with_msg(*args, **kwargs):
         return MockResponse(mock_events, status_code=200)
 
     elif args[0].endswith("namespaces"):
-        return MockResponse(
-            {"message": "Something went wrong."}, status_code=400
-        )
+        return MockResponse({"message": "Something went wrong."}, status_code=400)
 
 
 def mock_sensu_request_namespaces_not_ok_without_msg(*args, **kwargs):
@@ -3605,9 +2800,7 @@ def mock_delete_response_event_not_ok_with_msg(*args, **kwargs):
         return MockResponse(None, status_code=204)
 
     elif "events" in args[0]:
-        return MockResponse(
-            {"message": "Something went wrong."}, status_code=400
-        )
+        return MockResponse({"message": "Something went wrong."}, status_code=400)
 
     elif "entities" in args[0]:
         return MockResponse(None, status_code=204)
@@ -3625,20 +2818,15 @@ def mock_delete_response_entity_not_ok_with_msg(*args, **kwargs):
     return MockResponse({"message": "Something went wrong."}, status_code=400)
 
 
-def mock_delete_response_one_silenced_entry_not_ok_with_message(
-        *args, **kwargs
-):
+def mock_delete_response_one_silenced_entry_not_ok_with_message(*args, **kwargs):
     if args[0].endswith("entity:hostname2.example.com:generic.tcp.connect"):
-        return MockResponse(
-                {"message": "Something went wrong"}, status_code=400
-        )
+        return MockResponse({"message": "Something went wrong"}, status_code=400)
 
     else:
         return MockResponse(None, status_code=204)
 
-def mock_delete_response_one_silenced_entry_not_ok_without_message(
-        *args, **kwargs
-):
+
+def mock_delete_response_one_silenced_entry_not_ok_without_message(*args, **kwargs):
     if args[0].endswith("entity:hostname2.example.com:generic.tcp.connect"):
         return MockResponse(None, status_code=400)
 
@@ -3655,9 +2843,8 @@ def mock_function(*args, **kwargs):
 
 
 def mock_silenced_entry_delete_exception(*args, **kwargs):
-    if (
-            ("check" in kwargs and kwargs["check"] == "generic.tcp.connect") or
-            ("entity" in kwargs and kwargs["entity"] == "argo.ni4os.eu")
+    if ("check" in kwargs and kwargs["check"] == "generic.tcp.connect") or (
+        "entity" in kwargs and kwargs["entity"] == "argo.ni4os.eu"
     ):
         raise SCGWarnException(
             "Silenced entry entity:argo.ni4os.eu:generic.tcp.connect "
@@ -3674,8 +2861,8 @@ class SensuNamespaceTests(unittest.TestCase):
                 "Tenant1": ["Tenant1"],
                 "Tenant2": ["Tenant2"],
                 "TeNAnT3": ["Tenant3"],
-                "tenant4": ["TENANT4"]
-            }
+                "tenant4": ["TENANT4"],
+            },
         )
 
     @patch("requests.get")
@@ -3686,10 +2873,7 @@ class SensuNamespaceTests(unittest.TestCase):
             namespaces = self.sensu._get_namespaces()
         mock_get.assert_called_once_with(
             "https://sensu.mock.com:8080/api/core/v2/namespaces",
-            headers={
-                "Authorization": "Key t0k3n",
-                "Content-Type": "application/json"
-            }
+            headers={"Authorization": "Key t0k3n", "Content-Type": "application/json"},
         )
         self.assertEqual(sorted(namespaces), ["default", "tenant1", "tenant2"])
         self.assertEqual(log.output, [f"INFO:{LOGNAME}:dummy"])
@@ -3703,22 +2887,18 @@ class SensuNamespaceTests(unittest.TestCase):
 
         mock_get.assert_called_once_with(
             "https://sensu.mock.com:8080/api/core/v2/namespaces",
-            headers={
-                "Authorization": "Key t0k3n",
-                "Content-Type": "application/json"
-            }
+            headers={"Authorization": "Key t0k3n", "Content-Type": "application/json"},
         )
         self.assertEqual(
             context.exception.__str__(),
-            "Sensu error: Namespaces fetch error: 400 BAD REQUEST: "
-            "Something went wrong."
+            "Sensu error: Namespaces fetch error: 400 BAD REQUEST: Something went wrong.",
         )
         self.assertEqual(
-            log.output, [
-                f"ERROR:{LOGNAME}:Namespaces fetch error: "
-                f"400 BAD REQUEST: Something went wrong.",
-                f"WARNING:{LOGNAME}:Unable to proceed"
-            ]
+            log.output,
+            [
+                f"ERROR:{LOGNAME}:Namespaces fetch error: 400 BAD REQUEST: Something went wrong.",
+                f"WARNING:{LOGNAME}:Unable to proceed",
+            ],
         )
 
     @patch("requests.get")
@@ -3729,21 +2909,17 @@ class SensuNamespaceTests(unittest.TestCase):
                 self.sensu._get_namespaces()
         mock_get.assert_called_once_with(
             "https://sensu.mock.com:8080/api/core/v2/namespaces",
-            headers={
-                "Authorization": "Key t0k3n",
-                "Content-Type": "application/json"
-            }
+            headers={"Authorization": "Key t0k3n", "Content-Type": "application/json"},
         )
         self.assertEqual(
-            context.exception.__str__(),
-            "Sensu error: Namespaces fetch error: 400 BAD REQUEST"
+            context.exception.__str__(), "Sensu error: Namespaces fetch error: 400 BAD REQUEST"
         )
         self.assertEqual(
-            log.output, [
-                f"ERROR:{LOGNAME}:Namespaces fetch error: "
-                f"400 BAD REQUEST",
-                f"WARNING:{LOGNAME}:Unable to proceed"
-            ]
+            log.output,
+            [
+                f"ERROR:{LOGNAME}:Namespaces fetch error: 400 BAD REQUEST",
+                f"WARNING:{LOGNAME}:Unable to proceed",
+            ],
         )
 
     @patch("argo_scg.sensu.Sensu._get_namespaces")
@@ -3754,36 +2930,32 @@ class SensuNamespaceTests(unittest.TestCase):
         with self.assertLogs(LOGNAME) as log:
             self.sensu.handle_namespaces()
         self.assertEqual(mock_put.call_count, 2)
-        mock_put.assert_has_calls([
-            call(
-                "https://sensu.mock.com:8080/api/core/v2/namespaces/TeNAnT3",
-                data=json.dumps({"name": "TeNAnT3"}),
-                headers={
-                    "Authorization": "Key t0k3n",
-                    "Content-Type": "application/json"
-                }
-            ),
-            call(
-                "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant4",
-                data=json.dumps({"name": "tenant4"}),
-                headers={
-                    "Authorization": "Key t0k3n",
-                    "Content-Type": "application/json"
-                }
-            )
-        ], any_order=True)
+        mock_put.assert_has_calls(
+            [
+                call(
+                    "https://sensu.mock.com:8080/api/core/v2/namespaces/TeNAnT3",
+                    data=json.dumps({"name": "TeNAnT3"}),
+                    headers={"Authorization": "Key t0k3n", "Content-Type": "application/json"},
+                ),
+                call(
+                    "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant4",
+                    data=json.dumps({"name": "tenant4"}),
+                    headers={"Authorization": "Key t0k3n", "Content-Type": "application/json"},
+                ),
+            ],
+            any_order=True,
+        )
         self.assertEqual(
-            set(log.output), {
+            set(log.output),
+            {
                 f"INFO:{LOGNAME}:Namespace TeNAnT3 created",
-                f"INFO:{LOGNAME}:Namespace tenant4 created"
-            }
+                f"INFO:{LOGNAME}:Namespace tenant4 created",
+            },
         )
 
     @patch("argo_scg.sensu.Sensu._get_namespaces")
     @patch("requests.put")
-    def test_handle_namespaces_with_error_with_message(
-            self, mock_put, mock_namespace
-    ):
+    def test_handle_namespaces_with_error_with_message(self, mock_put, mock_namespace):
         mock_namespace.return_value = ["Tenant1", "Tenant2"]
         mock_put.side_effect = mock_post_response_not_ok_with_msg
         with self.assertRaises(SensuException) as context:
@@ -3791,30 +2963,25 @@ class SensuNamespaceTests(unittest.TestCase):
                 self.sensu.handle_namespaces()
         mock_put.assert_called_once_with(
             "https://sensu.mock.com:8080/api/core/v2/namespaces/TeNAnT3",
-            headers={
-                "Authorization": "Key t0k3n",
-                "Content-Type": "application/json"
-            },
-            data=json.dumps({"name": "TeNAnT3"})
+            headers={"Authorization": "Key t0k3n", "Content-Type": "application/json"},
+            data=json.dumps({"name": "TeNAnT3"}),
         )
         self.assertEqual(
             context.exception.__str__(),
-            "Sensu error: Namespace TeNAnT3 create error: 400 BAD REQUEST: "
-            "Something went wrong."
+            "Sensu error: Namespace TeNAnT3 create error: 400 BAD REQUEST: Something went wrong.",
         )
         self.assertEqual(
-            log.output, [
+            log.output,
+            [
                 f"ERROR:{LOGNAME}:Namespace TeNAnT3 create error: "
                 f"400 BAD REQUEST: Something went wrong.",
-                f"WARNING:{LOGNAME}:Unable to proceed"
-            ]
+                f"WARNING:{LOGNAME}:Unable to proceed",
+            ],
         )
 
     @patch("argo_scg.sensu.Sensu._get_namespaces")
     @patch("requests.put")
-    def test_handle_namespaces_with_error_without_message(
-            self, mock_put, mock_namespace
-    ):
+    def test_handle_namespaces_with_error_without_message(self, mock_put, mock_namespace):
         mock_namespace.return_value = ["Tenant1", "Tenant2"]
         mock_put.side_effect = mock_post_response_not_ok_without_msg
         with self.assertRaises(SensuException) as context:
@@ -3822,22 +2989,19 @@ class SensuNamespaceTests(unittest.TestCase):
                 self.sensu.handle_namespaces()
         mock_put.assert_called_once_with(
             "https://sensu.mock.com:8080/api/core/v2/namespaces/TeNAnT3",
-            headers={
-                "Authorization": "Key t0k3n",
-                "Content-Type": "application/json"
-            },
-            data=json.dumps({"name": "TeNAnT3"})
+            headers={"Authorization": "Key t0k3n", "Content-Type": "application/json"},
+            data=json.dumps({"name": "TeNAnT3"}),
         )
         self.assertEqual(
             context.exception.__str__(),
-            "Sensu error: Namespace TeNAnT3 create error: 400 BAD REQUEST"
+            "Sensu error: Namespace TeNAnT3 create error: 400 BAD REQUEST",
         )
         self.assertEqual(
-            log.output, [
-                f"ERROR:{LOGNAME}:Namespace TeNAnT3 create error: "
-                f"400 BAD REQUEST",
-                f"WARNING:{LOGNAME}:Unable to proceed"
-            ]
+            log.output,
+            [
+                f"ERROR:{LOGNAME}:Namespace TeNAnT3 create error: 400 BAD REQUEST",
+                f"WARNING:{LOGNAME}:Unable to proceed",
+            ],
         )
 
     @patch("argo_scg.sensu.Sensu._get_namespaces")
@@ -3845,7 +3009,7 @@ class SensuNamespaceTests(unittest.TestCase):
     @patch("requests.delete")
     @patch("requests.put")
     def test_handle_namespaces_with_deletion(
-            self, mock_put, mock_delete, mock_subprocess, mock_namespace
+        self, mock_put, mock_delete, mock_subprocess, mock_namespace
     ):
         mock_put.side_effect = mock_post_response
         mock_delete.side_effect = mock_delete_response
@@ -3854,39 +3018,38 @@ class SensuNamespaceTests(unittest.TestCase):
         with self.assertLogs(LOGNAME) as log:
             self.sensu.handle_namespaces()
         self.assertEqual(mock_put.call_count, 2)
-        mock_put.assert_has_calls([
-            call(
-                "https://sensu.mock.com:8080/api/core/v2/namespaces/TeNAnT3",
-                data=json.dumps({"name": "TeNAnT3"}),
-                headers={
-                    "Authorization": "Key t0k3n",
-                    "Content-Type": "application/json"
-                }
-            ),
-            call(
-                "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant4",
-                data=json.dumps({"name": "tenant4"}),
-                headers={
-                    "Authorization": "Key t0k3n",
-                    "Content-Type": "application/json"
-                }
-            )
-        ], any_order=True)
+        mock_put.assert_has_calls(
+            [
+                call(
+                    "https://sensu.mock.com:8080/api/core/v2/namespaces/TeNAnT3",
+                    data=json.dumps({"name": "TeNAnT3"}),
+                    headers={"Authorization": "Key t0k3n", "Content-Type": "application/json"},
+                ),
+                call(
+                    "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant4",
+                    data=json.dumps({"name": "tenant4"}),
+                    headers={"Authorization": "Key t0k3n", "Content-Type": "application/json"},
+                ),
+            ],
+            any_order=True,
+        )
         mock_subprocess.assert_called_once_with(
             "sensuctl dump entities,events,assets,checks,filters,handlers,"
-            "silenced --namespace Tenant5 | sensuctl delete", shell=True
+            "silenced --namespace Tenant5 | sensuctl delete",
+            shell=True,
         )
         mock_delete.assert_called_once_with(
             "https://sensu.mock.com:8080/api/core/v2/namespaces/Tenant5",
-            headers={"Authorization": "Key t0k3n"}
+            headers={"Authorization": "Key t0k3n"},
         )
         self.assertEqual(
-            set(log.output), {
+            set(log.output),
+            {
                 f"INFO:{LOGNAME}:Namespace TeNAnT3 created",
                 f"INFO:{LOGNAME}:Namespace tenant4 created",
                 f"INFO:{LOGNAME}:Namespace Tenant5 emptied",
-                f"INFO:{LOGNAME}:Namespace Tenant5 deleted"
-            }
+                f"INFO:{LOGNAME}:Namespace Tenant5 deleted",
+            },
         )
 
     @patch("argo_scg.sensu.Sensu._get_namespaces")
@@ -3894,7 +3057,7 @@ class SensuNamespaceTests(unittest.TestCase):
     @patch("requests.delete")
     @patch("requests.put")
     def test_handle_namespaces_with_deletion_subprocess_error(
-            self, mock_put, mock_delete, mock_subprocess, mock_namespace
+        self, mock_put, mock_delete, mock_subprocess, mock_namespace
     ):
         mock_put.side_effect = mock_delete_response
         mock_delete.side_effect = mock_post_response
@@ -3905,36 +3068,34 @@ class SensuNamespaceTests(unittest.TestCase):
         with self.assertLogs(LOGNAME) as log:
             self.sensu.handle_namespaces()
         self.assertEqual(mock_put.call_count, 2)
-        mock_put.assert_has_calls([
-            call(
-                "https://sensu.mock.com:8080/api/core/v2/namespaces/TeNAnT3",
-                data=json.dumps({"name": "TeNAnT3"}),
-                headers={
-                    "Authorization": "Key t0k3n",
-                    "Content-Type": "application/json"
-                }
-            ),
-            call(
-                "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant4",
-                data=json.dumps({"name": "tenant4"}),
-                headers={
-                    "Authorization": "Key t0k3n",
-                    "Content-Type": "application/json"
-                }
-            )
-        ], any_order=True)
+        mock_put.assert_has_calls(
+            [
+                call(
+                    "https://sensu.mock.com:8080/api/core/v2/namespaces/TeNAnT3",
+                    data=json.dumps({"name": "TeNAnT3"}),
+                    headers={"Authorization": "Key t0k3n", "Content-Type": "application/json"},
+                ),
+                call(
+                    "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant4",
+                    data=json.dumps({"name": "tenant4"}),
+                    headers={"Authorization": "Key t0k3n", "Content-Type": "application/json"},
+                ),
+            ],
+            any_order=True,
+        )
         mock_subprocess.assert_called_once_with(
             "sensuctl dump entities,events,assets,checks,filters,handlers,"
-            "silenced --namespace Tenant5 | sensuctl delete", shell=True
+            "silenced --namespace Tenant5 | sensuctl delete",
+            shell=True,
         )
         self.assertEqual(mock_delete.call_count, 0)
         self.assertEqual(
-            set(log.output), {
+            set(log.output),
+            {
                 f"INFO:{LOGNAME}:Namespace TeNAnT3 created",
                 f"INFO:{LOGNAME}:Namespace tenant4 created",
-                f"ERROR:{LOGNAME}:Error cleaning namespace Tenant5: "
-                f"There has been an error"
-            }
+                f"ERROR:{LOGNAME}:Error cleaning namespace Tenant5: There has been an error",
+            },
         )
 
     @patch("argo_scg.sensu.Sensu._get_namespaces")
@@ -3942,7 +3103,7 @@ class SensuNamespaceTests(unittest.TestCase):
     @patch("requests.delete")
     @patch("requests.put")
     def test_handle_namespaces_with_deletion_error_delete_api_with_msg(
-            self, mock_put, mock_delete, mock_subprocess, mock_namespace
+        self, mock_put, mock_delete, mock_subprocess, mock_namespace
     ):
         mock_put.side_effect = mock_post_response
         mock_delete.return_value = MockResponse(
@@ -3953,40 +3114,38 @@ class SensuNamespaceTests(unittest.TestCase):
         with self.assertLogs(LOGNAME) as log:
             self.sensu.handle_namespaces()
         self.assertEqual(mock_put.call_count, 2)
-        mock_put.assert_has_calls([
-            call(
-                "https://sensu.mock.com:8080/api/core/v2/namespaces/TeNAnT3",
-                data=json.dumps({"name": "TeNAnT3"}),
-                headers={
-                    "Authorization": "Key t0k3n",
-                    "Content-Type": "application/json"
-                }
-            ),
-            call(
-                "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant4",
-                data=json.dumps({"name": "tenant4"}),
-                headers={
-                    "Authorization": "Key t0k3n",
-                    "Content-Type": "application/json"
-                }
-            )
-        ], any_order=True)
+        mock_put.assert_has_calls(
+            [
+                call(
+                    "https://sensu.mock.com:8080/api/core/v2/namespaces/TeNAnT3",
+                    data=json.dumps({"name": "TeNAnT3"}),
+                    headers={"Authorization": "Key t0k3n", "Content-Type": "application/json"},
+                ),
+                call(
+                    "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant4",
+                    data=json.dumps({"name": "tenant4"}),
+                    headers={"Authorization": "Key t0k3n", "Content-Type": "application/json"},
+                ),
+            ],
+            any_order=True,
+        )
         mock_subprocess.assert_called_once_with(
             "sensuctl dump entities,events,assets,checks,filters,handlers,"
-            "silenced --namespace Tenant5 | sensuctl delete", shell=True
+            "silenced --namespace Tenant5 | sensuctl delete",
+            shell=True,
         )
         mock_delete.assert_called_once_with(
             "https://sensu.mock.com:8080/api/core/v2/namespaces/Tenant5",
-            headers={"Authorization": "Key t0k3n"}
+            headers={"Authorization": "Key t0k3n"},
         )
         self.assertEqual(
-            set(log.output), {
+            set(log.output),
+            {
                 f"INFO:{LOGNAME}:Namespace TeNAnT3 created",
                 f"INFO:{LOGNAME}:Namespace tenant4 created",
                 f"INFO:{LOGNAME}:Namespace Tenant5 emptied",
-                f"ERROR:{LOGNAME}:Error deleting Tenant5: 400 BAD REQUEST: "
-                f"Something went wrong"
-            }
+                f"ERROR:{LOGNAME}:Error deleting Tenant5: 400 BAD REQUEST: Something went wrong",
+            },
         )
 
     @patch("argo_scg.sensu.Sensu._get_namespaces")
@@ -3994,7 +3153,7 @@ class SensuNamespaceTests(unittest.TestCase):
     @patch("requests.delete")
     @patch("requests.put")
     def test_handle_namespaces_with_deletion_error_delete_api_without_msg(
-            self, mock_put, mock_delete, mock_subprocess, mock_namespace
+        self, mock_put, mock_delete, mock_subprocess, mock_namespace
     ):
         mock_put.side_effect = mock_post_response
         mock_delete.return_value = MockResponse(None, status_code=400)
@@ -4003,39 +3162,38 @@ class SensuNamespaceTests(unittest.TestCase):
         with self.assertLogs(LOGNAME) as log:
             self.sensu.handle_namespaces()
         self.assertEqual(mock_put.call_count, 2)
-        mock_put.assert_has_calls([
-            call(
-                "https://sensu.mock.com:8080/api/core/v2/namespaces/TeNAnT3",
-                data=json.dumps({"name": "TeNAnT3"}),
-                headers={
-                    "Authorization": "Key t0k3n",
-                    "Content-Type": "application/json"
-                }
-            ),
-            call(
-                "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant4",
-                data=json.dumps({"name": "tenant4"}),
-                headers={
-                    "Authorization": "Key t0k3n",
-                    "Content-Type": "application/json"
-                }
-            )
-        ], any_order=True)
+        mock_put.assert_has_calls(
+            [
+                call(
+                    "https://sensu.mock.com:8080/api/core/v2/namespaces/TeNAnT3",
+                    data=json.dumps({"name": "TeNAnT3"}),
+                    headers={"Authorization": "Key t0k3n", "Content-Type": "application/json"},
+                ),
+                call(
+                    "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant4",
+                    data=json.dumps({"name": "tenant4"}),
+                    headers={"Authorization": "Key t0k3n", "Content-Type": "application/json"},
+                ),
+            ],
+            any_order=True,
+        )
         mock_subprocess.assert_called_once_with(
             "sensuctl dump entities,events,assets,checks,filters,handlers,"
-            "silenced --namespace Tenant5 | sensuctl delete", shell=True
+            "silenced --namespace Tenant5 | sensuctl delete",
+            shell=True,
         )
         mock_delete.assert_called_once_with(
             "https://sensu.mock.com:8080/api/core/v2/namespaces/Tenant5",
-            headers={"Authorization": "Key t0k3n"}
+            headers={"Authorization": "Key t0k3n"},
         )
         self.assertEqual(
-            set(log.output), {
+            set(log.output),
+            {
                 f"INFO:{LOGNAME}:Namespace TeNAnT3 created",
                 f"INFO:{LOGNAME}:Namespace tenant4 created",
                 f"INFO:{LOGNAME}:Namespace Tenant5 emptied",
-                f"ERROR:{LOGNAME}:Error deleting Tenant5: 400 BAD REQUEST"
-            }
+                f"ERROR:{LOGNAME}:Error deleting Tenant5: 400 BAD REQUEST",
+            },
         )
 
 
@@ -4044,29 +3202,23 @@ class SensuCheckTests(unittest.TestCase):
         self.sensu = Sensu(
             url="https://sensu.mock.com:8080",
             token="t0k3n",
-            namespaces={
-                "default": ["default"],
-                "tenant1": ["TENANT1"],
-                "tenant2": ["TENANT2"]
-            }
+            namespaces={"default": ["default"], "tenant1": ["TENANT1"], "tenant2": ["TENANT2"]},
         )
         self.checks = [
             {
                 "command": "/usr/lib64/nagios/plugins/check_http "
-                           "-H {{ .labels.hostname }} -t 30 "
-                           "-r argo.eu "
-                           "-u /ni4os/report-ar/Critical/"
-                           "NGI?accept=csv "
-                           "--ssl --onredirect follow",
-                "subscriptions": [
-                    "entity:sensu-agent1"
-                ],
+                "-H {{ .labels.hostname }} -t 30 "
+                "-r argo.eu "
+                "-u /ni4os/report-ar/Critical/"
+                "NGI?accept=csv "
+                "--ssl --onredirect follow",
+                "subscriptions": ["entity:sensu-agent1"],
                 "handlers": ["publisher-handler"],
                 "proxy_requests": {
                     "entity_attributes": [
                         "entity.entity_class == 'proxy'",
                         "entity.labels.generic_http_ar_argoui_ni4os == "
-                        "'generic.http.ar-argoui-ni4os'"
+                        "'generic.http.ar-argoui-ni4os'",
                     ]
                 },
                 "interval": 300,
@@ -4075,26 +3227,21 @@ class SensuCheckTests(unittest.TestCase):
                 "metadata": {
                     "name": "generic.http.ar-argoui-ni4os",
                     "namespace": "tenant1",
-                    "annotations": {
-                        "attempts": "3"
-                    },
-                    "labels": {"tenants": "TENANT1"}
+                    "annotations": {"attempts": "3"},
+                    "labels": {"tenants": "TENANT1"},
                 },
                 "round_robin": True,
-                "pipelines": []
+                "pipelines": [],
             },
             {
                 "command": "/usr/lib64/nagios/plugins/check_tcp "
-                           "-H {{ .labels.hostname }} -t 120 -p 443",
-                "subscriptions": [
-                    "entity:sensu-agent1"
-                ],
+                "-H {{ .labels.hostname }} -t 120 -p 443",
+                "subscriptions": ["entity:sensu-agent1"],
                 "handlers": [],
                 "proxy_requests": {
                     "entity_attributes": [
                         "entity.entity_class == 'proxy'",
-                        "entity.labels.generic_tcp_connect == "
-                        "'generic.tcp.connect'"
+                        "entity.labels.generic_tcp_connect == 'generic.tcp.connect'",
                     ]
                 },
                 "interval": 300,
@@ -4103,34 +3250,30 @@ class SensuCheckTests(unittest.TestCase):
                 "metadata": {
                     "name": "generic.tcp.connect",
                     "namespace": "tenant1",
-                    "annotations": {
-                        "attempts": "3"
-                    },
-                    "labels": {"tenants": "TENANT1"}
+                    "annotations": {"attempts": "3"},
+                    "labels": {"tenants": "TENANT1"},
                 },
                 "round_robin": True,
-                "pipelines": []
+                "pipelines": [],
             },
             {
                 "command": "/usr/lib64/nagios/plugins/check_ssl_cert -H "
-                           "{{ .labels.hostname }} -t 60 -w 30 -c 0 -N "
-                           "--altnames "
-                           "--rootcert-dir /etc/grid-security/certificates"
-                           " --rootcert-file "
-                           "/etc/pki/tls/certs/ca-bundle.crt "
-                           "-C {{ .labels.ROBOT_CERT | "
-                           "default /etc/sensu/certs/hostcert.pem }} "
-                           "-K {{ .labels.ROBOT_KEY | "
-                           "default /etc/sensu/certs/hostkey.pem }}",
-                "subscriptions": [
-                    "entity:sensu-agent1"
-                ],
+                "{{ .labels.hostname }} -t 60 -w 30 -c 0 -N "
+                "--altnames "
+                "--rootcert-dir /etc/grid-security/certificates"
+                " --rootcert-file "
+                "/etc/pki/tls/certs/ca-bundle.crt "
+                "-C {{ .labels.ROBOT_CERT | "
+                "default /etc/sensu/certs/hostcert.pem }} "
+                "-K {{ .labels.ROBOT_KEY | "
+                "default /etc/sensu/certs/hostkey.pem }}",
+                "subscriptions": ["entity:sensu-agent1"],
                 "handlers": ["publisher-handler"],
                 "proxy_requests": {
                     "entity_attributes": [
                         "entity.entity_class == 'proxy'",
                         "entity.labels.generic_certificate_validity == "
-                        "'generic.certificate.validity'"
+                        "'generic.certificate.validity'",
                     ]
                 },
                 "interval": 14400,
@@ -4139,14 +3282,12 @@ class SensuCheckTests(unittest.TestCase):
                 "metadata": {
                     "name": "generic.certificate.validity",
                     "namespace": "tenant1",
-                    "annotations": {
-                        "attempts": "2"
-                    },
-                    "labels": {"tenants": "TENANT1"}
+                    "annotations": {"attempts": "2"},
+                    "labels": {"tenants": "TENANT1"},
                 },
                 "round_robin": True,
-                "pipelines": []
-            }
+                "pipelines": [],
+            },
         ]
 
     @patch("requests.get")
@@ -4158,10 +3299,7 @@ class SensuCheckTests(unittest.TestCase):
 
         mock_get.assert_called_once_with(
             "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant1/checks",
-            headers={
-                "Authorization": "Key t0k3n",
-                "Content-Type": "application/json"
-            }
+            headers={"Authorization": "Key t0k3n", "Content-Type": "application/json"},
         )
 
         self.assertEqual(checks, mock_checks)
@@ -4177,22 +3315,19 @@ class SensuCheckTests(unittest.TestCase):
 
         mock_get.assert_called_once_with(
             "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant1/checks",
-            headers={
-                "Authorization": "Key t0k3n",
-                "Content-Type": "application/json"
-            }
+            headers={"Authorization": "Key t0k3n", "Content-Type": "application/json"},
         )
 
         self.assertEqual(
             context.exception.__str__(),
-            "Sensu error: tenant1: Checks fetch error: 400 BAD REQUEST: "
-            "Something went wrong."
+            "Sensu error: tenant1: Checks fetch error: 400 BAD REQUEST: Something went wrong.",
         )
         self.assertEqual(
-            log.output, [
+            log.output,
+            [
                 f"ERROR:{LOGNAME}:tenant1: Checks fetch error: "
                 f"400 BAD REQUEST: Something went wrong."
-            ]
+            ],
         )
 
     @patch("requests.get")
@@ -4205,21 +3340,14 @@ class SensuCheckTests(unittest.TestCase):
 
         mock_get.assert_called_once_with(
             "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant1/checks",
-            headers={
-                "Authorization": "Key t0k3n",
-                "Content-Type": "application/json"
-            }
+            headers={"Authorization": "Key t0k3n", "Content-Type": "application/json"},
         )
 
         self.assertEqual(
-            context.exception.__str__(),
-            "Sensu error: tenant1: Checks fetch error: 400 BAD REQUEST"
+            context.exception.__str__(), "Sensu error: tenant1: Checks fetch error: 400 BAD REQUEST"
         )
         self.assertEqual(
-            log.output, [
-                f"ERROR:{LOGNAME}:tenant1: Checks fetch error: "
-                f"400 BAD REQUEST"
-            ]
+            log.output, [f"ERROR:{LOGNAME}:tenant1: Checks fetch error: 400 BAD REQUEST"]
         )
 
     @patch("argo_scg.sensu.Sensu._delete_silenced_entry")
@@ -4232,145 +3360,134 @@ class SensuCheckTests(unittest.TestCase):
                 checks=[
                     "generic.tcp.connect",
                     "generic.http.connect",
-                    "generic.certificate.validity"
+                    "generic.certificate.validity",
                 ],
-                namespace="tenant1"
+                namespace="tenant1",
             )
         self.assertEqual(mock_delete.call_count, 3)
-        mock_delete.assert_has_calls([
-            call(
-                "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant1/"
-                "checks/generic.tcp.connect",
-                headers={
-                    "Authorization": "Key t0k3n"
-                }
-            ),
-            call(
-                "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant1/"
-                "checks/generic.http.connect",
-                headers={
-                    "Authorization": "Key t0k3n"
-                }
-            ),
-            call(
-                "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant1/"
-                "checks/generic.certificate.validity",
-                headers={
-                    "Authorization": "Key t0k3n"
-                }
-            )
-        ], any_order=True)
+        mock_delete.assert_has_calls(
+            [
+                call(
+                    "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant1/"
+                    "checks/generic.tcp.connect",
+                    headers={"Authorization": "Key t0k3n"},
+                ),
+                call(
+                    "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant1/"
+                    "checks/generic.http.connect",
+                    headers={"Authorization": "Key t0k3n"},
+                ),
+                call(
+                    "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant1/"
+                    "checks/generic.certificate.validity",
+                    headers={"Authorization": "Key t0k3n"},
+                ),
+            ],
+            any_order=True,
+        )
         self.assertEqual(mock_delete_silenced.call_count, 3)
-        mock_delete_silenced.assert_has_calls([
-            call(check="generic.tcp.connect", namespace="tenant1"),
-            call(check="generic.http.connect", namespace="tenant1"),
-            call(check="generic.certificate.validity", namespace="tenant1")
-        ])
+        mock_delete_silenced.assert_has_calls(
+            [
+                call(check="generic.tcp.connect", namespace="tenant1"),
+                call(check="generic.http.connect", namespace="tenant1"),
+                call(check="generic.certificate.validity", namespace="tenant1"),
+            ]
+        )
         self.assertEqual(
-            set(log.output), {
-                f"INFO:{LOGNAME}:tenant1: "
-                f"Check generic.tcp.connect removed",
-                f"INFO:{LOGNAME}:tenant1: "
-                f"Check generic.http.connect removed",
-                f"INFO:{LOGNAME}:tenant1: "
-                f"Check generic.certificate.validity removed"
-            }
+            set(log.output),
+            {
+                f"INFO:{LOGNAME}:tenant1: Check generic.tcp.connect removed",
+                f"INFO:{LOGNAME}:tenant1: Check generic.http.connect removed",
+                f"INFO:{LOGNAME}:tenant1: Check generic.certificate.validity removed",
+            },
         )
 
     @patch("argo_scg.sensu.Sensu._delete_silenced_entry")
     @patch("requests.delete")
-    def test_delete_checks_with_error_with_message(
-            self, mock_delete, mock_delete_silenced
-    ):
+    def test_delete_checks_with_error_with_message(self, mock_delete, mock_delete_silenced):
         mock_delete.side_effect = [
             MockResponse({"message": "Something went wrong."}, status_code=400),
-            MockResponse(None, status_code=204)
+            MockResponse(None, status_code=204),
         ]
         mock_delete_silenced.side_effect = mock_function
         with self.assertLogs(LOGNAME) as log:
             self.sensu._delete_checks(
-                checks=["generic.tcp.connect", "generic.http.connect"],
-                namespace="tenant1"
+                checks=["generic.tcp.connect", "generic.http.connect"], namespace="tenant1"
             )
         self.assertEqual(mock_delete.call_count, 2)
-        mock_delete.assert_has_calls([
-            call(
-                "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant1/"
-                "checks/generic.tcp.connect",
-                headers={
-                    "Authorization": "Key t0k3n"
-                }
-            ),
-            call(
-                "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant1/"
-                "checks/generic.http.connect",
-                headers={
-                    "Authorization": "Key t0k3n"
-                }
-            )
-        ], any_order=True)
+        mock_delete.assert_has_calls(
+            [
+                call(
+                    "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant1/"
+                    "checks/generic.tcp.connect",
+                    headers={"Authorization": "Key t0k3n"},
+                ),
+                call(
+                    "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant1/"
+                    "checks/generic.http.connect",
+                    headers={"Authorization": "Key t0k3n"},
+                ),
+            ],
+            any_order=True,
+        )
         mock_delete_silenced.assert_called_once_with(
             check="generic.http.connect", namespace="tenant1"
         )
         self.assertEqual(
-            set(log.output), {
+            set(log.output),
+            {
                 f"WARNING:{LOGNAME}:tenant1: "
                 f"Check generic.tcp.connect not removed: "
                 f"400 BAD REQUEST: Something went wrong.",
-                f"INFO:{LOGNAME}:tenant1: "
-                f"Check generic.http.connect removed"
-            }
+                f"INFO:{LOGNAME}:tenant1: Check generic.http.connect removed",
+            },
         )
 
     @patch("argo_scg.sensu.Sensu._delete_silenced_entry")
     @patch("requests.delete")
-    def test_delete_checks_with_error_without_message(
-            self, mock_delete, mock_delete_silenced
-    ):
+    def test_delete_checks_with_error_without_message(self, mock_delete, mock_delete_silenced):
         mock_delete.side_effect = [
             MockResponse(None, status_code=400),
-            MockResponse(None, status_code=204)
+            MockResponse(None, status_code=204),
         ]
         mock_delete_silenced.side_effect = mock_function
         with self.assertLogs(LOGNAME) as log:
             self.sensu._delete_checks(
-                checks=["generic.tcp.connect", "generic.http.connect"],
-                namespace="tenant1"
+                checks=["generic.tcp.connect", "generic.http.connect"], namespace="tenant1"
             )
         self.assertEqual(mock_delete.call_count, 2)
-        mock_delete.assert_has_calls([
-            call(
-                "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant1/"
-                "checks/generic.tcp.connect",
-                headers={
-                    "Authorization": "Key t0k3n"
-                }
-            ),
-            call(
-                "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant1/"
-                "checks/generic.http.connect",
-                headers={
-                    "Authorization": "Key t0k3n"
-                }
-            )
-        ], any_order=True)
+        mock_delete.assert_has_calls(
+            [
+                call(
+                    "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant1/"
+                    "checks/generic.tcp.connect",
+                    headers={"Authorization": "Key t0k3n"},
+                ),
+                call(
+                    "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant1/"
+                    "checks/generic.http.connect",
+                    headers={"Authorization": "Key t0k3n"},
+                ),
+            ],
+            any_order=True,
+        )
         mock_delete_silenced.assert_called_once_with(
             check="generic.http.connect", namespace="tenant1"
         )
         self.assertEqual(
-            set(log.output), {
+            set(log.output),
+            {
                 f"WARNING:{LOGNAME}:tenant1: "
                 f"Check generic.tcp.connect not removed: "
                 f"400 BAD REQUEST",
-                f"INFO:{LOGNAME}:tenant1: "
-                f"Check generic.http.connect removed"
-            }
+                f"INFO:{LOGNAME}:tenant1: Check generic.http.connect removed",
+            },
         )
 
     @patch("argo_scg.sensu.Sensu._delete_silenced_entry")
     @patch("requests.delete")
     def test_delete_checks_with_error_with_silenced_entries(
-            self, mock_delete, mock_delete_silenced
+        self, mock_delete, mock_delete_silenced
     ):
         mock_delete.side_effect = mock_delete_response
         mock_delete_silenced.side_effect = mock_silenced_entry_delete_exception
@@ -4379,52 +3496,49 @@ class SensuCheckTests(unittest.TestCase):
                 checks=[
                     "generic.tcp.connect",
                     "generic.http.connect",
-                    "generic.certificate.validity"
+                    "generic.certificate.validity",
                 ],
-                namespace="tenant1"
+                namespace="tenant1",
             )
         self.assertEqual(mock_delete.call_count, 3)
-        mock_delete.assert_has_calls([
-            call(
-                "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant1/"
-                "checks/generic.tcp.connect",
-                headers={
-                    "Authorization": "Key t0k3n"
-                }
-            ),
-            call(
-                "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant1/"
-                "checks/generic.http.connect",
-                headers={
-                    "Authorization": "Key t0k3n"
-                }
-            ),
-            call(
-                "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant1/"
-                "checks/generic.certificate.validity",
-                headers={
-                    "Authorization": "Key t0k3n"
-                }
-            )
-        ], any_order=True)
+        mock_delete.assert_has_calls(
+            [
+                call(
+                    "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant1/"
+                    "checks/generic.tcp.connect",
+                    headers={"Authorization": "Key t0k3n"},
+                ),
+                call(
+                    "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant1/"
+                    "checks/generic.http.connect",
+                    headers={"Authorization": "Key t0k3n"},
+                ),
+                call(
+                    "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant1/"
+                    "checks/generic.certificate.validity",
+                    headers={"Authorization": "Key t0k3n"},
+                ),
+            ],
+            any_order=True,
+        )
         self.assertEqual(mock_delete_silenced.call_count, 3)
-        mock_delete_silenced.assert_has_calls([
-            call(check="generic.tcp.connect", namespace="tenant1"),
-            call(check="generic.http.connect", namespace="tenant1"),
-            call(check="generic.certificate.validity", namespace="tenant1")
-        ])
+        mock_delete_silenced.assert_has_calls(
+            [
+                call(check="generic.tcp.connect", namespace="tenant1"),
+                call(check="generic.http.connect", namespace="tenant1"),
+                call(check="generic.certificate.validity", namespace="tenant1"),
+            ]
+        )
         self.assertEqual(
-            set(log.output), {
-                f"INFO:{LOGNAME}:tenant1: "
-                f"Check generic.tcp.connect removed",
-                f"INFO:{LOGNAME}:tenant1: "
-                f"Check generic.http.connect removed",
-                f"INFO:{LOGNAME}:tenant1: "
-                f"Check generic.certificate.validity removed",
+            set(log.output),
+            {
+                f"INFO:{LOGNAME}:tenant1: Check generic.tcp.connect removed",
+                f"INFO:{LOGNAME}:tenant1: Check generic.http.connect removed",
+                f"INFO:{LOGNAME}:tenant1: Check generic.certificate.validity removed",
                 f"WARNING:{LOGNAME}:tenant1: Silenced entry "
                 f"entity:argo.ni4os.eu:generic.tcp.connect "
-                f"(400 BAD REQUEST: Something went wrong) not removed"
-            }
+                f"(400 BAD REQUEST: Something went wrong) not removed",
+            },
         )
 
     @patch("argo_scg.sensu.Sensu._delete_silenced_entry")
@@ -4432,15 +3546,10 @@ class SensuCheckTests(unittest.TestCase):
     def test_delete_single_check(self, mock_delete, mock_delete_silenced):
         mock_delete.side_effect = mock_delete_response
         mock_delete_silenced.side_effect = mock_function
-        self.sensu.delete_check(
-            check="generic.tcp.connect", namespace="tenant1"
-        )
+        self.sensu.delete_check(check="generic.tcp.connect", namespace="tenant1")
         mock_delete.assert_called_once_with(
-            "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant1/checks/"
-            "generic.tcp.connect",
-            headers={
-                "Authorization": "Key t0k3n"
-            }
+            "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant1/checks/generic.tcp.connect",
+            headers={"Authorization": "Key t0k3n"},
         )
         mock_delete_silenced.assert_called_once_with(
             check="generic.tcp.connect", namespace="tenant1"
@@ -4448,73 +3557,53 @@ class SensuCheckTests(unittest.TestCase):
 
     @patch("argo_scg.sensu.Sensu._delete_silenced_entry")
     @patch("requests.delete")
-    def test_delete_single_check_with_error_with_message(
-            self, mock_delete, mock_delete_silenced
-    ):
+    def test_delete_single_check_with_error_with_message(self, mock_delete, mock_delete_silenced):
         mock_delete.return_value = MockResponse(
             {"message": "Something went wrong"}, status_code=400
         )
         mock_delete_silenced.side_effect = mock_function
         with self.assertRaises(SensuException) as context:
-            self.sensu.delete_check(
-                check="generic.tcp.connect", namespace="tenant1"
-            )
+            self.sensu.delete_check(check="generic.tcp.connect", namespace="tenant1")
         mock_delete.assert_called_once_with(
-            "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant1/checks/"
-            "generic.tcp.connect",
-            headers={
-                "Authorization": "Key t0k3n"
-            }
+            "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant1/checks/generic.tcp.connect",
+            headers={"Authorization": "Key t0k3n"},
         )
         self.assertEqual(
             context.exception.__str__(),
             "Sensu error: tenant1: Check generic.tcp.connect not removed: "
-            "400 BAD REQUEST: Something went wrong"
+            "400 BAD REQUEST: Something went wrong",
         )
         self.assertFalse(mock_delete_silenced.called)
 
     @patch("argo_scg.sensu.Sensu._delete_silenced_entry")
     @patch("requests.delete")
     def test_delete_single_check_with_error_without_message(
-            self, mock_delete, mock_delete_silenced
+        self, mock_delete, mock_delete_silenced
     ):
         mock_delete.return_value = MockResponse(None, status_code=400)
         mock_delete_silenced.side_effect = mock_function
         with self.assertRaises(SensuException) as context:
-            self.sensu.delete_check(
-                check="generic.tcp.connect", namespace="tenant1"
-            )
+            self.sensu.delete_check(check="generic.tcp.connect", namespace="tenant1")
         mock_delete.assert_called_once_with(
-            "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant1/checks/"
-            "generic.tcp.connect",
-            headers={
-                "Authorization": "Key t0k3n"
-            }
+            "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant1/checks/generic.tcp.connect",
+            headers={"Authorization": "Key t0k3n"},
         )
         self.assertEqual(
             context.exception.__str__(),
-            "Sensu error: tenant1: Check generic.tcp.connect not removed: "
-            "400 BAD REQUEST"
+            "Sensu error: tenant1: Check generic.tcp.connect not removed: 400 BAD REQUEST",
         )
         self.assertFalse(mock_delete_silenced.called)
 
     @patch("argo_scg.sensu.Sensu._delete_silenced_entry")
     @patch("requests.delete")
-    def test_delete_single_check_with_silenced_entry_error(
-            self, mock_delete, mock_delete_silenced
-    ):
+    def test_delete_single_check_with_silenced_entry_error(self, mock_delete, mock_delete_silenced):
         mock_delete.side_effect = mock_delete_response
         mock_delete_silenced.side_effect = mock_silenced_entry_delete_exception
         with self.assertRaises(SCGWarnException) as context:
-            self.sensu.delete_check(
-                check="generic.tcp.connect", namespace="tenant1"
-            )
+            self.sensu.delete_check(check="generic.tcp.connect", namespace="tenant1")
         mock_delete.assert_called_once_with(
-            "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant1/checks/"
-            "generic.tcp.connect",
-            headers={
-                "Authorization": "Key t0k3n"
-            }
+            "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant1/checks/generic.tcp.connect",
+            headers={"Authorization": "Key t0k3n"},
         )
         mock_delete_silenced.assert_called_once_with(
             check="generic.tcp.connect", namespace="tenant1"
@@ -4522,7 +3611,7 @@ class SensuCheckTests(unittest.TestCase):
         self.assertEqual(
             context.exception.__str__(),
             "Silenced entry entity:argo.ni4os.eu:generic.tcp.connect "
-            "(400 BAD REQUEST: Something went wrong) not removed"
+            "(400 BAD REQUEST: Something went wrong) not removed",
         )
 
     @patch("requests.put")
@@ -4531,12 +3620,15 @@ class SensuCheckTests(unittest.TestCase):
     @patch("argo_scg.sensu.Sensu._fetch_events")
     @patch("argo_scg.sensu.Sensu._get_checks")
     def test_handle_check(
-            self, mock_get_checks, mock_get_events, mock_delete_checks,
-            mock_delete_events, mock_put
+        self, mock_get_checks, mock_get_events, mock_delete_checks, mock_delete_events, mock_put
     ):
         checks2 = [
-            mock_checks[0], mock_checks[1], mock_checks[2], mock_checks[3],
-            mock_checks[4], self.checks[2]
+            mock_checks[0],
+            mock_checks[1],
+            mock_checks[2],
+            mock_checks[3],
+            mock_checks[4],
+            self.checks[2],
         ]
         checks3 = [checks2[0], checks2[2], checks2[3], checks2[4], checks2[5]]
         mock_get_checks.side_effect = [mock_checks, checks2, checks3]
@@ -4552,44 +3644,36 @@ class SensuCheckTests(unittest.TestCase):
         mock_get_checks.assert_called_with(namespace="tenant1")
         mock_get_events.assert_called_once_with(namespace="tenant1")
         mock_delete_checks.assert_called_once_with(
-            checks=["generic.http.status-argoui-ni4os"],
-            namespace="tenant1"
+            checks=["generic.http.status-argoui-ni4os"], namespace="tenant1"
         )
         mock_delete_events.assert_called_once_with(
-            events={
-                "argo.ni4os.eu": ["generic.http.status-argoui-ni4os"]
-            },
-            namespace="tenant1"
+            events={"argo.ni4os.eu": ["generic.http.status-argoui-ni4os"]}, namespace="tenant1"
         )
         self.assertEqual(mock_put.call_count, 2)
-        mock_put.assert_has_calls([
-            call(
-                "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant1/"
-                "checks/generic.http.ar-argoui-ni4os",
-                data=json.dumps(self.checks[0]),
-                headers={
-                    "Authorization": "Key t0k3n",
-                    "Content-Type": "application/json"
-                }
-            ),
-            call(
-                "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant1/"
-                "checks/generic.certificate.validity",
-                data=json.dumps(self.checks[2]),
-                headers={
-                    "Authorization": "Key t0k3n",
-                    "Content-Type": "application/json"
-                }
-            )
-        ], any_order=True)
+        mock_put.assert_has_calls(
+            [
+                call(
+                    "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant1/"
+                    "checks/generic.http.ar-argoui-ni4os",
+                    data=json.dumps(self.checks[0]),
+                    headers={"Authorization": "Key t0k3n", "Content-Type": "application/json"},
+                ),
+                call(
+                    "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant1/"
+                    "checks/generic.certificate.validity",
+                    data=json.dumps(self.checks[2]),
+                    headers={"Authorization": "Key t0k3n", "Content-Type": "application/json"},
+                ),
+            ],
+            any_order=True,
+        )
 
         self.assertEqual(
-            set(log.output), {
-                f"INFO:{LOGNAME}:tenant1: Check generic.certificate.validity "
-                f"created",
-                f"INFO:{LOGNAME}:tenant1: Check generic.http.ar-argoui-ni4os "
-                f"updated"
-            }
+            set(log.output),
+            {
+                f"INFO:{LOGNAME}:tenant1: Check generic.certificate.validity created",
+                f"INFO:{LOGNAME}:tenant1: Check generic.http.ar-argoui-ni4os updated",
+            },
         )
 
     @patch("requests.put")
@@ -4598,8 +3682,7 @@ class SensuCheckTests(unittest.TestCase):
     @patch("argo_scg.sensu.Sensu._fetch_events")
     @patch("argo_scg.sensu.Sensu._get_checks")
     def test_handle_check_with_changing_handler(
-            self, mock_get_checks, mock_get_events, mock_delete_checks,
-            mock_delete_events, mock_put
+        self, mock_get_checks, mock_get_events, mock_delete_checks, mock_delete_events, mock_put
     ):
         check1 = mock_checks[0].copy()
         check1.pop("high_flap_threshold")
@@ -4628,24 +3711,15 @@ class SensuCheckTests(unittest.TestCase):
         mock_get_checks.assert_called_with(namespace="tenant1")
         mock_get_events.assert_called_once_with(namespace="tenant1")
         mock_delete_checks.assert_called_once_with(
-            checks=["generic.http.status-argoui-ni4os"],
-            namespace="tenant1"
+            checks=["generic.http.status-argoui-ni4os"], namespace="tenant1"
         )
         mock_put.assert_called_once_with(
-            "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant1/checks/"
-            "generic.tcp.connect",
+            "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant1/checks/generic.tcp.connect",
             data=json.dumps(check2),
-            headers={
-                "Authorization": "Key t0k3n",
-                "Content-Type": "application/json"
-            }
+            headers={"Authorization": "Key t0k3n", "Content-Type": "application/json"},
         )
 
-        self.assertEqual(
-            log.output, [
-                f"INFO:{LOGNAME}:tenant1: Check generic.tcp.connect updated"
-            ]
-        )
+        self.assertEqual(log.output, [f"INFO:{LOGNAME}:tenant1: Check generic.tcp.connect updated"])
 
     @patch("requests.put")
     @patch("argo_scg.sensu.Sensu._delete_events")
@@ -4653,72 +3727,58 @@ class SensuCheckTests(unittest.TestCase):
     @patch("argo_scg.sensu.Sensu._fetch_events")
     @patch("argo_scg.sensu.Sensu._get_checks")
     def test_handle_check_with_hardcoded_attributes(
-            self, mock_get_checks, mock_get_events, mock_delete_checks,
-            mock_delete_events, mock_put
+        self, mock_get_checks, mock_get_events, mock_delete_checks, mock_delete_events, mock_put
     ):
         checks = [
             {
                 "command": "/usr/libexec/argo-monitoring/probes/activemq/"
-                           "check_activemq_openwire "
-                           "-t 30 --keystoretype jks "
-                           "-s monitor.test.$_SERVICESERVER$.$HOSTALIAS$."
-                           "openwiressl "
-                           "-K {{ .labels.KEYSTORE | default "
-                           "/etc/sensu/certs/keystore.jks }} "
-                           "-T {{ .labels.TRUSTSTORE | default "
-                           "/etc/sensu/certs/truststore.ts }}",
-                "subscriptions": [
-                    "entity:sensu-agent1"
-                ],
+                "check_activemq_openwire "
+                "-t 30 --keystoretype jks "
+                "-s monitor.test.$_SERVICESERVER$.$HOSTALIAS$."
+                "openwiressl "
+                "-K {{ .labels.KEYSTORE | default "
+                "/etc/sensu/certs/keystore.jks }} "
+                "-T {{ .labels.TRUSTSTORE | default "
+                "/etc/sensu/certs/truststore.ts }}",
+                "subscriptions": ["entity:sensu-agent1"],
                 "handlers": ["publisher-handler"],
                 "proxy_requests": {
                     "entity_attributes": [
                         "entity.entity_class == 'proxy'",
-                        "entity.labels.org_activemq_openwiressl == "
-                        "'org.activemq.OpenWireSSL'"
+                        "entity.labels.org_activemq_openwiressl == 'org.activemq.OpenWireSSL'",
                     ]
                 },
                 "interval": 300,
                 "timeout": 30,
                 "publish": True,
-                "metadata": {
-                    "name": "org.activemq.OpenWireSSL",
-                    "namespace": "TENANT1"
-                },
-                "round_robin": True
+                "metadata": {"name": "org.activemq.OpenWireSSL", "namespace": "TENANT1"},
+                "round_robin": True,
             },
             {
                 "command": "/usr/libexec/argo-monitoring/probes/midmon/"
-                           "check_bdii_entries_num "
-                           "-t 30 -b Mds-Vo-Name=local,O=grid -c 4:4 "
-                           "-f \"(GlueServiceEndpoint=*$HOSTALIAS$*)\" "
-                           "-p {{ .labels.BDII_PORT | default 2170 }} "
-                           "-H {{ .labels.BDII_HOST }}",
-                "subscriptions": [
-                    "entity:sensu-agent1"
-                ],
+                "check_bdii_entries_num "
+                "-t 30 -b Mds-Vo-Name=local,O=grid -c 4:4 "
+                '-f "(GlueServiceEndpoint=*$HOSTALIAS$*)" '
+                "-p {{ .labels.BDII_PORT | default 2170 }} "
+                "-H {{ .labels.BDII_HOST }}",
+                "subscriptions": ["entity:sensu-agent1"],
                 "handlers": ["publisher-handler"],
                 "proxy_requests": {
                     "entity_attributes": [
                         "entity.entity_class == 'proxy'",
                         "entity.labels.org_nagiosexchange_broker_bdii == "
-                        "'org.nagiosexchange.Broker-BDII'"
+                        "'org.nagiosexchange.Broker-BDII'",
                     ]
                 },
                 "interval": 21600,
                 "timeout": 30,
                 "publish": True,
-                "metadata": {
-                    "name": "org.nagiosexchange.Broker-BDII",
-                    "namespace": "TENANT1"
-                },
-                "round_robin": True
-            }
+                "metadata": {"name": "org.nagiosexchange.Broker-BDII", "namespace": "TENANT1"},
+                "round_robin": True,
+            },
         ]
 
-        checks2 = [
-            mock_checks[0], mock_checks[1], mock_checks[2], checks[0], checks[1]
-        ]
+        checks2 = [mock_checks[0], mock_checks[1], mock_checks[2], checks[0], checks[1]]
 
         mock_get_checks.side_effect = [mock_checks, checks2, checks]
         mock_get_events.return_value = mock_events
@@ -4735,51 +3795,45 @@ class SensuCheckTests(unittest.TestCase):
             checks=[
                 "generic.http.ar-argoui-ni4os",
                 "generic.http.status-argoui-ni4os",
-                "generic.tcp.connect"
+                "generic.tcp.connect",
             ],
-            namespace="tenant1"
+            namespace="tenant1",
         )
         mock_delete_events.assert_called_once_with(
             events={
                 "argo.ni4os.eu": [
                     "generic.http.ar-argoui-ni4os",
-                    "generic.http.status-argoui-ni4os"
+                    "generic.http.status-argoui-ni4os",
                 ],
-                "gocdb.ni4os.eu": [
-                    "generic.tcp.connect"
-                ]
+                "gocdb.ni4os.eu": ["generic.tcp.connect"],
             },
-            namespace="tenant1"
+            namespace="tenant1",
         )
         self.assertEqual(mock_put.call_count, 2)
-        mock_put.assert_has_calls([
-            call(
-                "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant1/"
-                "checks/org.activemq.OpenWireSSL",
-                data=json.dumps(checks[0]),
-                headers={
-                    "Authorization": "Key t0k3n",
-                    "Content-Type": "application/json"
-                }
-            ),
-            call(
-                "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant1/"
-                "checks/org.nagiosexchange.Broker-BDII",
-                data=json.dumps(checks[1]),
-                headers={
-                    "Authorization": "Key t0k3n",
-                    "Content-Type": "application/json"
-                }
-            )
-        ], any_order=True)
+        mock_put.assert_has_calls(
+            [
+                call(
+                    "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant1/"
+                    "checks/org.activemq.OpenWireSSL",
+                    data=json.dumps(checks[0]),
+                    headers={"Authorization": "Key t0k3n", "Content-Type": "application/json"},
+                ),
+                call(
+                    "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant1/"
+                    "checks/org.nagiosexchange.Broker-BDII",
+                    data=json.dumps(checks[1]),
+                    headers={"Authorization": "Key t0k3n", "Content-Type": "application/json"},
+                ),
+            ],
+            any_order=True,
+        )
 
         self.assertEqual(
-            set(log.output), {
-                f"INFO:{LOGNAME}:tenant1: Check org.activemq.OpenWireSSL "
-                f"created",
-                f"INFO:{LOGNAME}:tenant1: Check org.nagiosexchange.Broker-BDII "
-                f"created"
-            }
+            set(log.output),
+            {
+                f"INFO:{LOGNAME}:tenant1: Check org.activemq.OpenWireSSL created",
+                f"INFO:{LOGNAME}:tenant1: Check org.nagiosexchange.Broker-BDII created",
+            },
         )
 
     @patch("requests.put")
@@ -4788,67 +3842,53 @@ class SensuCheckTests(unittest.TestCase):
     @patch("argo_scg.sensu.Sensu._fetch_events")
     @patch("argo_scg.sensu.Sensu._get_checks")
     def test_handle_check_with_file_defined_attributes(
-            self, mock_get_checks, mock_get_events, mock_delete_checks,
-            mock_delete_events, mock_put
+        self, mock_get_checks, mock_get_events, mock_delete_checks, mock_delete_events, mock_put
     ):
         checks = [
             {
                 "command": "/usr/libexec/argo-monitoring/probes/"
-                           "eudat-b2access/check_b2access_simple.py "
-                           "-H {{ .labels.hostname }} "
-                           "--url https://b2access.fz-juelich.de:8443 "
-                           "--username username --password pa55w0rD",
-                "subscriptions": [
-                    "entity:sensu-agent1"
-                ],
+                "eudat-b2access/check_b2access_simple.py "
+                "-H {{ .labels.hostname }} "
+                "--url https://b2access.fz-juelich.de:8443 "
+                "--username username --password pa55w0rD",
+                "subscriptions": ["entity:sensu-agent1"],
                 "handlers": ["publisher-handler"],
                 "proxy_requests": {
                     "entity_attributes": [
                         "entity.entity_class == 'proxy'",
                         "entity.labels.eudat_b2access_unity_login_local == "
-                        "'eudat.b2access.unity.login-local'"
+                        "'eudat.b2access.unity.login-local'",
                     ]
                 },
                 "interval": 900,
                 "timeout": 120,
                 "publish": True,
-                "metadata": {
-                    "name": "eudat.b2access.unity.login-local",
-                    "namespace": "TENANT1"
-                },
-                "round_robin": True
+                "metadata": {"name": "eudat.b2access.unity.login-local", "namespace": "TENANT1"},
+                "round_robin": True,
             },
             {
                 "command": "/usr/libexec/grid-monitoring/probes/"
-                           "org.qoscosgrid/computing/check_qcg_comp "
-                           "-H {{ .labels.hostname }} -t 600 "
-                           "-p {{ .labels.QCG-COMPUTING_PORT | "
-                           "default 19000 }} -x",
-                "subscriptions": [
-                    "entity:sensu-agent1"
-                ],
+                "org.qoscosgrid/computing/check_qcg_comp "
+                "-H {{ .labels.hostname }} -t 600 "
+                "-p {{ .labels.QCG-COMPUTING_PORT | "
+                "default 19000 }} -x",
+                "subscriptions": ["entity:sensu-agent1"],
                 "handlers": ["publisher-handler"],
                 "proxy_requests": {
                     "entity_attributes": [
                         "entity.entity_class == 'proxy'",
-                        "entity.labels.pl_plgrid_qcg_computing == "
-                        "'pl.plgrid.QCG-Computing'"
+                        "entity.labels.pl_plgrid_qcg_computing == 'pl.plgrid.QCG-Computing'",
                     ]
                 },
                 "interval": 1800,
                 "timeout": 600,
                 "publish": True,
-                "metadata": {
-                    "name": "pl.plgrid.QCG-Computing",
-                    "namespace": "TENANT1"
-                },
-                "round_robin": True
-            }
+                "metadata": {"name": "pl.plgrid.QCG-Computing", "namespace": "TENANT1"},
+                "round_robin": True,
+            },
         ]
 
-        checks2 = [
-            mock_checks[0], mock_checks[1], mock_checks[2], checks[0], checks[1]
-        ]
+        checks2 = [mock_checks[0], mock_checks[1], mock_checks[2], checks[0], checks[1]]
 
         mock_get_checks.side_effect = [mock_checks, checks2, checks]
         mock_get_events.return_value = mock_events
@@ -4866,52 +3906,45 @@ class SensuCheckTests(unittest.TestCase):
             checks=[
                 "generic.http.ar-argoui-ni4os",
                 "generic.http.status-argoui-ni4os",
-                "generic.tcp.connect"
+                "generic.tcp.connect",
             ],
-            namespace="tenant1"
+            namespace="tenant1",
         )
         mock_delete_events.assert_called_once_with(
             events={
                 "argo.ni4os.eu": [
                     "generic.http.ar-argoui-ni4os",
-                    "generic.http.status-argoui-ni4os"
+                    "generic.http.status-argoui-ni4os",
                 ],
-                "gocdb.ni4os.eu": [
-                    "generic.tcp.connect"
-                ]
+                "gocdb.ni4os.eu": ["generic.tcp.connect"],
             },
-            namespace="tenant1"
+            namespace="tenant1",
         )
         self.assertEqual(mock_put.call_count, 2)
-        mock_put.assert_has_calls([
-            call(
-                "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant1/"
-                "checks/eudat.b2access.unity.login-local",
-                data=json.dumps(checks[0]),
-                headers={
-                    "Authorization": "Key t0k3n",
-                    "Content-Type": "application/json"
-                }
-            ),
-            call(
-                "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant1/"
-                "checks/pl.plgrid.QCG-Computing",
-                data=json.dumps(checks[1]),
-                headers={
-                    "Authorization": "Key t0k3n",
-                    "Content-Type": "application/json"
-                }
-            )
-        ],
-            any_order=True
+        mock_put.assert_has_calls(
+            [
+                call(
+                    "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant1/"
+                    "checks/eudat.b2access.unity.login-local",
+                    data=json.dumps(checks[0]),
+                    headers={"Authorization": "Key t0k3n", "Content-Type": "application/json"},
+                ),
+                call(
+                    "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant1/"
+                    "checks/pl.plgrid.QCG-Computing",
+                    data=json.dumps(checks[1]),
+                    headers={"Authorization": "Key t0k3n", "Content-Type": "application/json"},
+                ),
+            ],
+            any_order=True,
         )
 
         self.assertEqual(
-            set(log.output), {
-                f"INFO:{LOGNAME}:tenant1: Check "
-                f"eudat.b2access.unity.login-local created",
-                f"INFO:{LOGNAME}:tenant1: Check pl.plgrid.QCG-Computing created"
-            }
+            set(log.output),
+            {
+                f"INFO:{LOGNAME}:tenant1: Check eudat.b2access.unity.login-local created",
+                f"INFO:{LOGNAME}:tenant1: Check pl.plgrid.QCG-Computing created",
+            },
         )
 
     @patch("requests.put")
@@ -4920,23 +3953,20 @@ class SensuCheckTests(unittest.TestCase):
     @patch("argo_scg.sensu.Sensu._fetch_events")
     @patch("argo_scg.sensu.Sensu._get_checks")
     def test_handle_check_with_removing_proxy_requests(
-            self, mock_get_checks, mock_get_events, mock_delete_checks,
-            mock_delete_events, mock_put
+        self, mock_get_checks, mock_get_events, mock_delete_checks, mock_delete_events, mock_put
     ):
         mock_checks_small = [mock_checks[0], mock_checks[2]]
         no_proxy_checks = [
             {
                 "command": "/usr/lib64/nagios/plugins/check_tcp "
-                           "-H {{ .labels.hostname }} -t 120 -p 443",
+                "-H {{ .labels.hostname }} -t 120 -p 443",
                 "handlers": [],
                 "high_flap_threshold": 0,
                 "interval": 300,
                 "low_flap_threshold": 0,
                 "publish": True,
                 "runtime_assets": None,
-                "subscriptions": [
-                    "entity:sensu-agent1"
-                ],
+                "subscriptions": ["entity:sensu-agent1"],
                 "proxy_entity_name": "",
                 "check_hooks": None,
                 "stdin": False,
@@ -4950,17 +3980,15 @@ class SensuCheckTests(unittest.TestCase):
                 "metadata": {
                     "name": "generic.tcp.connect",
                     "namespace": "TENANT1",
-                    "created_by": "root"
+                    "created_by": "root",
                 },
                 "secrets": None,
-                "pipelines": []
+                "pipelines": [],
             }
         ]
 
         checks2 = [mock_checks[0], no_proxy_checks[0]]
-        mock_get_checks.side_effect = [
-            mock_checks_small, checks2, no_proxy_checks
-        ]
+        mock_get_checks.side_effect = [mock_checks_small, checks2, no_proxy_checks]
         mock_get_events.return_value = [mock_events[0], mock_events[1]]
         mock_delete_checks.side_effect = mock_delete_response
         mock_delete_events.side_effect = mock_delete_response
@@ -4973,30 +4001,18 @@ class SensuCheckTests(unittest.TestCase):
         mock_get_checks.assert_called_with(namespace="tenant1")
         mock_get_events.assert_called_once_with(namespace="tenant1")
         mock_delete_checks.assert_called_once_with(
-            checks=["generic.http.ar-argoui-ni4os"],
-            namespace="tenant1"
+            checks=["generic.http.ar-argoui-ni4os"], namespace="tenant1"
         )
         mock_delete_events.assert_called_once_with(
-            events={
-                "argo.ni4os.eu": ["generic.http.ar-argoui-ni4os"]
-            },
-            namespace="tenant1"
+            events={"argo.ni4os.eu": ["generic.http.ar-argoui-ni4os"]}, namespace="tenant1"
         )
         mock_put.assert_called_once_with(
-            "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant1/checks/"
-            "generic.tcp.connect",
+            "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant1/checks/generic.tcp.connect",
             data=json.dumps(no_proxy_checks[0]),
-            headers={
-                "Authorization": "Key t0k3n",
-                "Content-Type": "application/json"
-            }
+            headers={"Authorization": "Key t0k3n", "Content-Type": "application/json"},
         )
 
-        self.assertEqual(
-            log.output, [
-                f"INFO:{LOGNAME}:tenant1: Check generic.tcp.connect updated"
-            ]
-        )
+        self.assertEqual(log.output, [f"INFO:{LOGNAME}:tenant1: Check generic.tcp.connect updated"])
 
     @patch("requests.put")
     @patch("argo_scg.sensu.Sensu._delete_events")
@@ -5004,8 +4020,7 @@ class SensuCheckTests(unittest.TestCase):
     @patch("argo_scg.sensu.Sensu._fetch_events")
     @patch("argo_scg.sensu.Sensu._get_checks")
     def test_handle_check_with_changing_handler(
-            self, mock_get_checks, mock_get_events, mock_delete_checks,
-            mock_delete_events, mock_put
+        self, mock_get_checks, mock_get_events, mock_delete_checks, mock_delete_events, mock_put
     ):
         check1 = mock_checks[0].copy()
         check1.pop("high_flap_threshold")
@@ -5034,24 +4049,15 @@ class SensuCheckTests(unittest.TestCase):
         mock_get_checks.assert_called_with(namespace="tenant1")
         mock_get_events.assert_called_once_with(namespace="tenant1")
         mock_delete_checks.assert_called_once_with(
-            checks=["generic.http.status-argoui-ni4os"],
-            namespace="tenant1"
+            checks=["generic.http.status-argoui-ni4os"], namespace="tenant1"
         )
         mock_put.assert_called_once_with(
-            "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant1/checks/"
-            "generic.tcp.connect",
+            "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant1/checks/generic.tcp.connect",
             data=json.dumps(check2),
-            headers={
-                "Authorization": "Key t0k3n",
-                "Content-Type": "application/json"
-            }
+            headers={"Authorization": "Key t0k3n", "Content-Type": "application/json"},
         )
 
-        self.assertEqual(
-            log.output, [
-                f"INFO:{LOGNAME}:tenant1: Check generic.tcp.connect updated"
-            ]
-        )
+        self.assertEqual(log.output, [f"INFO:{LOGNAME}:tenant1: Check generic.tcp.connect updated"])
 
     @patch("requests.put")
     @patch("argo_scg.sensu.Sensu._delete_events")
@@ -5059,15 +4065,18 @@ class SensuCheckTests(unittest.TestCase):
     @patch("argo_scg.sensu.Sensu._fetch_events")
     @patch("argo_scg.sensu.Sensu._get_checks")
     def test_handle_check_if_changing_labels(
-            self, mock_get_checks, mock_get_events, mock_delete_checks,
-            mock_delete_events, mock_put
+        self, mock_get_checks, mock_get_events, mock_delete_checks, mock_delete_events, mock_put
     ):
         copied_mock_checks = [copy.deepcopy(item) for item in mock_checks]
         copied_mock_checks[0]["metadata"].pop("labels")
         copied_mock_checks[2]["metadata"]["labels"]["tenants"] = "TENANT2"
         checks2 = [
-            mock_checks[0], mock_checks[1], mock_checks[2], mock_checks[3],
-            mock_checks[4], self.checks[2]
+            mock_checks[0],
+            mock_checks[1],
+            mock_checks[2],
+            mock_checks[3],
+            mock_checks[4],
+            self.checks[2],
         ]
         checks3 = [checks2[0], checks2[2], checks2[3], checks2[4], checks2[5]]
         mock_get_checks.side_effect = [copied_mock_checks, checks2, checks3]
@@ -5083,54 +4092,43 @@ class SensuCheckTests(unittest.TestCase):
         mock_get_checks.assert_called_with(namespace="tenant1")
         mock_get_events.assert_called_once_with(namespace="tenant1")
         mock_delete_checks.assert_called_once_with(
-            checks=["generic.http.status-argoui-ni4os"],
-            namespace="tenant1"
+            checks=["generic.http.status-argoui-ni4os"], namespace="tenant1"
         )
         mock_delete_events.assert_called_once_with(
-            events={
-                "argo.ni4os.eu": ["generic.http.status-argoui-ni4os"]
-            },
-            namespace="tenant1"
+            events={"argo.ni4os.eu": ["generic.http.status-argoui-ni4os"]}, namespace="tenant1"
         )
         self.assertEqual(mock_put.call_count, 3)
-        mock_put.assert_has_calls([
-            call(
-                "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant1/"
-                "checks/generic.http.ar-argoui-ni4os",
-                data=json.dumps(self.checks[0]),
-                headers={
-                    "Authorization": "Key t0k3n",
-                    "Content-Type": "application/json"
-                }
-            ),
-            call(
-                "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant1/"
-                "checks/generic.certificate.validity",
-                data=json.dumps(self.checks[2]),
-                headers={
-                    "Authorization": "Key t0k3n",
-                    "Content-Type": "application/json"
-                }
-            ),
-            call(
-                "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant1/"
-                "checks/generic.tcp.connect",
-                data=json.dumps(self.checks[1]),
-                headers={
-                    "Authorization": "Key t0k3n",
-                    "Content-Type": "application/json"
-                }
-            ),
-        ], any_order=True)
+        mock_put.assert_has_calls(
+            [
+                call(
+                    "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant1/"
+                    "checks/generic.http.ar-argoui-ni4os",
+                    data=json.dumps(self.checks[0]),
+                    headers={"Authorization": "Key t0k3n", "Content-Type": "application/json"},
+                ),
+                call(
+                    "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant1/"
+                    "checks/generic.certificate.validity",
+                    data=json.dumps(self.checks[2]),
+                    headers={"Authorization": "Key t0k3n", "Content-Type": "application/json"},
+                ),
+                call(
+                    "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant1/"
+                    "checks/generic.tcp.connect",
+                    data=json.dumps(self.checks[1]),
+                    headers={"Authorization": "Key t0k3n", "Content-Type": "application/json"},
+                ),
+            ],
+            any_order=True,
+        )
 
         self.assertEqual(
-            set(log.output), {
-                f"INFO:{LOGNAME}:tenant1: Check generic.certificate.validity "
-                f"created",
-                f"INFO:{LOGNAME}:tenant1: Check generic.http.ar-argoui-ni4os "
-                f"updated",
-                f"INFO:{LOGNAME}:tenant1: Check generic.tcp.connect updated"
-            }
+            set(log.output),
+            {
+                f"INFO:{LOGNAME}:tenant1: Check generic.certificate.validity created",
+                f"INFO:{LOGNAME}:tenant1: Check generic.http.ar-argoui-ni4os updated",
+                f"INFO:{LOGNAME}:tenant1: Check generic.tcp.connect updated",
+            },
         )
 
     @patch("requests.put")
@@ -5139,24 +4137,18 @@ class SensuCheckTests(unittest.TestCase):
     @patch("argo_scg.sensu.Sensu._fetch_events")
     @patch("argo_scg.sensu.Sensu._get_checks")
     def test_handle_passive_check_if_new(
-            self, mock_get_checks, mock_get_events, mock_delete_checks,
-            mock_delete_events, mock_put
+        self, mock_get_checks, mock_get_events, mock_delete_checks, mock_delete_events, mock_put
     ):
         passive_check = {
             "command": "PASSIVE",
-            "subscriptions": [
-                "entity:sensu-agent1"
-            ],
+            "subscriptions": ["entity:sensu-agent1"],
             "handlers": [],
             "pipelines": [],
             "cron": "CRON_TZ=Europe/Zagreb 0 0 31 2 *",
             "timeout": 900,
             "publish": False,
-            "metadata": {
-                "name": "eu.egi.SRM-VOGet",
-                "namespace": "mockspace"
-            },
-            "round_robin": False
+            "metadata": {"name": "eu.egi.SRM-VOGet", "namespace": "mockspace"},
+            "round_robin": False,
         }
         mock_get_checks.return_value = self.checks
         mock_get_events.return_value = mock_events
@@ -5175,20 +4167,12 @@ class SensuCheckTests(unittest.TestCase):
         self.assertFalse(mock_delete_checks.called)
         self.assertFalse(mock_delete_events.called)
         mock_put.assert_called_once_with(
-            "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant1/checks/"
-            "eu.egi.SRM-VOGet",
+            "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant1/checks/eu.egi.SRM-VOGet",
             data=json.dumps(passive_check),
-            headers={
-                "Authorization": "Key t0k3n",
-                "Content-Type": "application/json"
-            }
+            headers={"Authorization": "Key t0k3n", "Content-Type": "application/json"},
         )
 
-        self.assertEqual(
-            log.output, [
-                f"INFO:{LOGNAME}:tenant1: Check eu.egi.SRM-VOGet created"
-            ]
-        )
+        self.assertEqual(log.output, [f"INFO:{LOGNAME}:tenant1: Check eu.egi.SRM-VOGet created"])
 
     @patch("requests.put")
     @patch("argo_scg.sensu.Sensu._delete_events")
@@ -5196,55 +4180,49 @@ class SensuCheckTests(unittest.TestCase):
     @patch("argo_scg.sensu.Sensu._fetch_events")
     @patch("argo_scg.sensu.Sensu._get_checks")
     def test_handle_passive_check_if_existing(
-            self, mock_get_checks, mock_get_events, mock_delete_checks,
-            mock_delete_events, mock_put
+        self, mock_get_checks, mock_get_events, mock_delete_checks, mock_delete_events, mock_put
     ):
         passive_check = {
             "command": "PASSIVE",
-            "subscriptions": [
-                "entity:sensu-agent1"
-            ],
+            "subscriptions": ["entity:sensu-agent1"],
             "handlers": [],
             "pipelines": [],
             "cron": "CRON_TZ=Europe/Zagreb 0 0 31 2 *",
             "timeout": 900,
             "publish": False,
-            "metadata": {
-                "name": "eu.egi.SRM-VOGet",
-                "namespace": "mockspace"
-            },
-            "round_robin": False
-        }
-        mock_get_checks.return_value = self.checks + [{
-            "command": "PASSIVE",
-            "handlers": [],
-            "high_flap_threshold": 0,
-            "interval": 0,
-            "low_flap_threshold": 0,
-            "publish": False,
-            "runtime_assets": None,
-            "subscriptions": [
-                "entity:sensu-agent1"
-            ],
-            "proxy_entity_name": "",
-            "check_hooks": None,
-            "stdin": False,
-            "subdue": None,
-            "cron": "CRON_TZ=Europe/Zagreb 0 0 31 2 *",
-            "ttl": 0,
-            "timeout": 900,
+            "metadata": {"name": "eu.egi.SRM-VOGet", "namespace": "mockspace"},
             "round_robin": False,
-            "output_metric_format": "",
-            "output_metric_handlers": None,
-            "env_vars": None,
-            "metadata": {
-                "name": "eu.egi.SRM-VOGet",
-                "namespace": "mockspace",
-                "created_by": "admin"
-            },
-            "secrets": None,
-            "pipelines": []
-        }]
+        }
+        mock_get_checks.return_value = self.checks + [
+            {
+                "command": "PASSIVE",
+                "handlers": [],
+                "high_flap_threshold": 0,
+                "interval": 0,
+                "low_flap_threshold": 0,
+                "publish": False,
+                "runtime_assets": None,
+                "subscriptions": ["entity:sensu-agent1"],
+                "proxy_entity_name": "",
+                "check_hooks": None,
+                "stdin": False,
+                "subdue": None,
+                "cron": "CRON_TZ=Europe/Zagreb 0 0 31 2 *",
+                "ttl": 0,
+                "timeout": 900,
+                "round_robin": False,
+                "output_metric_format": "",
+                "output_metric_handlers": None,
+                "env_vars": None,
+                "metadata": {
+                    "name": "eu.egi.SRM-VOGet",
+                    "namespace": "mockspace",
+                    "created_by": "admin",
+                },
+                "secrets": None,
+                "pipelines": [],
+            }
+        ]
         mock_get_events.return_value = mock_events
         mock_delete_checks.side_effect = mock_delete_response
         mock_delete_events.side_effect = mock_delete_response
@@ -5271,12 +4249,9 @@ class SensuCheckTests(unittest.TestCase):
     @patch("argo_scg.sensu.Sensu._fetch_events")
     @patch("argo_scg.sensu.Sensu._get_checks")
     def test_handle_checks_with_error_in_put_check_with_msg(
-            self, mock_get_checks, mock_get_events, mock_delete_checks,
-            mock_delete_events, mock_put
+        self, mock_get_checks, mock_get_events, mock_delete_checks, mock_delete_events, mock_put
     ):
-        checks2 = [
-            mock_checks[0], mock_checks[1], mock_checks[2], self.checks[2]
-        ]
+        checks2 = [mock_checks[0], mock_checks[1], mock_checks[2], self.checks[2]]
         checks3 = [checks2[0], checks2[2], checks2[3]]
         mock_get_checks.side_effect = [mock_checks, checks2, checks3]
         mock_get_events.return_value = mock_events
@@ -5284,7 +4259,7 @@ class SensuCheckTests(unittest.TestCase):
         mock_delete_events.side_effect = mock_delete_response
         mock_put.side_effect = [
             MockResponse(None, status_code=200),
-            MockResponse({"message": "Something went wrong."}, status_code=400)
+            MockResponse({"message": "Something went wrong."}, status_code=400),
         ]
 
         with self.assertLogs(LOGNAME) as log:
@@ -5294,45 +4269,38 @@ class SensuCheckTests(unittest.TestCase):
         mock_get_checks.assert_called_with(namespace="tenant1")
         mock_get_events.assert_called_once_with(namespace="tenant1")
         mock_delete_checks.assert_called_once_with(
-            checks=["generic.http.status-argoui-ni4os"],
-            namespace="tenant1"
+            checks=["generic.http.status-argoui-ni4os"], namespace="tenant1"
         )
         mock_delete_events.assert_called_once_with(
-            events={
-                "argo.ni4os.eu": ["generic.http.status-argoui-ni4os"]
-            },
-            namespace="tenant1"
+            events={"argo.ni4os.eu": ["generic.http.status-argoui-ni4os"]}, namespace="tenant1"
         )
         self.assertEqual(mock_put.call_count, 2)
-        mock_put.assert_has_calls([
-            call(
-                "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant1/"
-                "checks/generic.http.ar-argoui-ni4os",
-                data=json.dumps(self.checks[0]),
-                headers={
-                    "Authorization": "Key t0k3n",
-                    "Content-Type": "application/json"
-                }
-            ),
-            call(
-                "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant1/"
-                "checks/generic.certificate.validity",
-                data=json.dumps(self.checks[2]),
-                headers={
-                    "Authorization": "Key t0k3n",
-                    "Content-Type": "application/json"
-                }
-            )
-        ], any_order=True)
+        mock_put.assert_has_calls(
+            [
+                call(
+                    "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant1/"
+                    "checks/generic.http.ar-argoui-ni4os",
+                    data=json.dumps(self.checks[0]),
+                    headers={"Authorization": "Key t0k3n", "Content-Type": "application/json"},
+                ),
+                call(
+                    "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant1/"
+                    "checks/generic.certificate.validity",
+                    data=json.dumps(self.checks[2]),
+                    headers={"Authorization": "Key t0k3n", "Content-Type": "application/json"},
+                ),
+            ],
+            any_order=True,
+        )
 
         self.assertEqual(
-            set(log.output), {
+            set(log.output),
+            {
                 f"WARNING:{LOGNAME}:tenant1: Check "
                 f"generic.certificate.validity not created: "
                 f"400 BAD REQUEST: Something went wrong.",
-                f"INFO:{LOGNAME}:tenant1: Check generic.http.ar-argoui-ni4os "
-                f"updated"
-            }
+                f"INFO:{LOGNAME}:tenant1: Check generic.http.ar-argoui-ni4os updated",
+            },
         )
 
     @patch("requests.put")
@@ -5341,12 +4309,9 @@ class SensuCheckTests(unittest.TestCase):
     @patch("argo_scg.sensu.Sensu._fetch_events")
     @patch("argo_scg.sensu.Sensu._get_checks")
     def test_handle_checks_with_error_in_put_check_without_msg(
-            self, mock_get_checks, mock_get_events, mock_delete_checks,
-            mock_delete_events, mock_put
+        self, mock_get_checks, mock_get_events, mock_delete_checks, mock_delete_events, mock_put
     ):
-        checks2 = [
-            mock_checks[0], mock_checks[1], mock_checks[2], self.checks[2]
-        ]
+        checks2 = [mock_checks[0], mock_checks[1], mock_checks[2], self.checks[2]]
         checks3 = [checks2[0], checks2[2], checks2[3]]
         mock_get_checks.side_effect = [mock_checks, checks2, checks3]
         mock_get_events.return_value = mock_events
@@ -5354,7 +4319,7 @@ class SensuCheckTests(unittest.TestCase):
         mock_delete_events.side_effect = mock_delete_response
         mock_put.side_effect = [
             MockResponse(None, status_code=200),
-            MockResponse(None, status_code=400)
+            MockResponse(None, status_code=400),
         ]
 
         with self.assertLogs(LOGNAME) as log:
@@ -5364,156 +4329,116 @@ class SensuCheckTests(unittest.TestCase):
         mock_get_checks.assert_called_with(namespace="tenant1")
         mock_get_events.assert_called_once_with(namespace="tenant1")
         mock_delete_checks.assert_called_once_with(
-            checks=["generic.http.status-argoui-ni4os"],
-            namespace="tenant1"
+            checks=["generic.http.status-argoui-ni4os"], namespace="tenant1"
         )
         mock_delete_events.assert_called_once_with(
-            events={
-                "argo.ni4os.eu": ["generic.http.status-argoui-ni4os"]
-            },
-            namespace="tenant1"
+            events={"argo.ni4os.eu": ["generic.http.status-argoui-ni4os"]}, namespace="tenant1"
         )
         self.assertEqual(mock_put.call_count, 2)
-        mock_put.assert_has_calls([
-            call(
-                "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant1/"
-                "checks/generic.http.ar-argoui-ni4os",
-                data=json.dumps(self.checks[0]),
-                headers={
-                    "Authorization": "Key t0k3n",
-                    "Content-Type": "application/json"
-                }
-            ),
-            call(
-                "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant1/"
-                "checks/generic.certificate.validity",
-                data=json.dumps(self.checks[2]),
-                headers={
-                    "Authorization": "Key t0k3n",
-                    "Content-Type": "application/json"
-                }
-            )
-        ], any_order=True)
+        mock_put.assert_has_calls(
+            [
+                call(
+                    "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant1/"
+                    "checks/generic.http.ar-argoui-ni4os",
+                    data=json.dumps(self.checks[0]),
+                    headers={"Authorization": "Key t0k3n", "Content-Type": "application/json"},
+                ),
+                call(
+                    "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant1/"
+                    "checks/generic.certificate.validity",
+                    data=json.dumps(self.checks[2]),
+                    headers={"Authorization": "Key t0k3n", "Content-Type": "application/json"},
+                ),
+            ],
+            any_order=True,
+        )
 
         self.assertEqual(
-            set(log.output), {
+            set(log.output),
+            {
                 f"WARNING:{LOGNAME}:tenant1: Check "
                 f"generic.certificate.validity not created: "
                 f"400 BAD REQUEST",
-                f"INFO:{LOGNAME}:tenant1: Check generic.http.ar-argoui-ni4os "
-                f"updated"
-            }
+                f"INFO:{LOGNAME}:tenant1: Check generic.http.ar-argoui-ni4os updated",
+            },
         )
 
     @patch("requests.put")
     def test_put_check(self, mock_put):
         mock_put.side_effect = mock_post_response
         check = {
-            "command": "/usr/lib64/nagios/plugins/check_tcp -H argo.ni4os.eu "
-                       "-t 120 -p 443",
-            "subscriptions": [
-                "entity:sensu-agent1"
-            ],
+            "command": "/usr/lib64/nagios/plugins/check_tcp -H argo.ni4os.eu -t 120 -p 443",
+            "subscriptions": ["entity:sensu-agent1"],
             "handlers": [],
             "interval": 86400,
             "timeout": 900,
             "publish": False,
-            "metadata": {
-                "name": "adhoc-check",
-                "namespace": "TENANT1"
-            },
-            "round_robin": False
+            "metadata": {"name": "adhoc-check", "namespace": "TENANT1"},
+            "round_robin": False,
         }
 
         self.sensu.put_check(check=check, namespace="tenant1")
         mock_put.assert_called_once_with(
-            "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant1/checks/"
-            "adhoc-check",
+            "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant1/checks/adhoc-check",
             data=json.dumps(check),
-            headers={
-                "Authorization": "Key t0k3n",
-                "Content-Type": "application/json"
-            }
+            headers={"Authorization": "Key t0k3n", "Content-Type": "application/json"},
         )
 
     @patch("requests.put")
     def test_put_check_with_error_with_message(self, mock_put):
-        mock_put.return_value = MockResponse(
-            {"message": "Something went wrong"}, status_code=400
-        )
+        mock_put.return_value = MockResponse({"message": "Something went wrong"}, status_code=400)
         check = {
-            "command": "/usr/lib64/nagios/plugins/check_tcp -H argo.ni4os.eu "
-                       "-t 120 -p 443",
-            "subscriptions": [
-                "entity:sensu-agent1"
-            ],
+            "command": "/usr/lib64/nagios/plugins/check_tcp -H argo.ni4os.eu -t 120 -p 443",
+            "subscriptions": ["entity:sensu-agent1"],
             "handlers": [],
             "interval": 86400,
             "timeout": 900,
             "publish": False,
-            "metadata": {
-                "name": "adhoc-check",
-                "namespace": "TENANT1"
-            },
-            "round_robin": False
+            "metadata": {"name": "adhoc-check", "namespace": "TENANT1"},
+            "round_robin": False,
         }
 
         with self.assertRaises(SensuException) as context:
             self.sensu.put_check(check=check, namespace="tenant1")
 
         mock_put.assert_called_once_with(
-            "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant1/checks/"
-            "adhoc-check",
+            "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant1/checks/adhoc-check",
             data=json.dumps(check),
-            headers={
-                "Authorization": "Key t0k3n",
-                "Content-Type": "application/json"
-            }
+            headers={"Authorization": "Key t0k3n", "Content-Type": "application/json"},
         )
 
         self.assertEqual(
             context.exception.__str__(),
             "Sensu error: tenant1: Check adhoc-check not created: "
-            "400 BAD REQUEST: Something went wrong"
+            "400 BAD REQUEST: Something went wrong",
         )
 
     @patch("requests.put")
     def test_put_check_with_error_without_message(self, mock_put):
         mock_put.return_value = MockResponse(None, status_code=400)
         check = {
-            "command": "/usr/lib64/nagios/plugins/check_tcp -H argo.ni4os.eu "
-                       "-t 120 -p 443",
-            "subscriptions": [
-                "entity:sensu-agent1"
-            ],
+            "command": "/usr/lib64/nagios/plugins/check_tcp -H argo.ni4os.eu -t 120 -p 443",
+            "subscriptions": ["entity:sensu-agent1"],
             "handlers": [],
             "interval": 86400,
             "timeout": 900,
             "publish": False,
-            "metadata": {
-                "name": "adhoc-check",
-                "namespace": "TENANT1"
-            },
-            "round_robin": False
+            "metadata": {"name": "adhoc-check", "namespace": "TENANT1"},
+            "round_robin": False,
         }
 
         with self.assertRaises(SensuException) as context:
             self.sensu.put_check(check=check, namespace="tenant1")
 
         mock_put.assert_called_once_with(
-            "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant1/checks/"
-            "adhoc-check",
+            "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant1/checks/adhoc-check",
             data=json.dumps(check),
-            headers={
-                "Authorization": "Key t0k3n",
-                "Content-Type": "application/json"
-            }
+            headers={"Authorization": "Key t0k3n", "Content-Type": "application/json"},
         )
 
         self.assertEqual(
             context.exception.__str__(),
-            "Sensu error: tenant1: Check adhoc-check not created: "
-            "400 BAD REQUEST"
+            "Sensu error: tenant1: Check adhoc-check not created: 400 BAD REQUEST",
         )
 
 
@@ -5522,11 +4447,7 @@ class SensuEventsTests(unittest.TestCase):
         self.sensu = Sensu(
             url="https://sensu.mock.com:8080",
             token="t0k3n",
-            namespaces={
-                "default": ["default"],
-                "tenant1": ["TENANT1"],
-                "tenant2": ["TENANT2"]
-            }
+            namespaces={"default": ["default"], "tenant1": ["TENANT1"], "tenant2": ["TENANT2"]},
         )
 
     @patch("requests.get")
@@ -5548,22 +4469,19 @@ class SensuEventsTests(unittest.TestCase):
 
         mock_get.assert_called_once_with(
             "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant1/events",
-            headers={
-                "Authorization": "Key t0k3n",
-                "Content-Type": "application/json"
-            }
+            headers={"Authorization": "Key t0k3n", "Content-Type": "application/json"},
         )
 
         self.assertEqual(
             context.exception.__str__(),
-            "Sensu error: tenant1: Events fetch error: 400 BAD REQUEST: "
-            "Something went wrong."
+            "Sensu error: tenant1: Events fetch error: 400 BAD REQUEST: Something went wrong.",
         )
         self.assertEqual(
-            log.output, [
+            log.output,
+            [
                 f"WARNING:{LOGNAME}:tenant1: Events fetch error: "
                 f"400 BAD REQUEST: Something went wrong."
-            ]
+            ],
         )
 
     @patch("requests.get")
@@ -5576,21 +4494,14 @@ class SensuEventsTests(unittest.TestCase):
 
         mock_get.assert_called_once_with(
             "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant1/events",
-            headers={
-                "Authorization": "Key t0k3n",
-                "Content-Type": "application/json"
-            }
+            headers={"Authorization": "Key t0k3n", "Content-Type": "application/json"},
         )
 
         self.assertEqual(
-            context.exception.__str__(),
-            "Sensu error: tenant1: Events fetch error: 400 BAD REQUEST"
+            context.exception.__str__(), "Sensu error: tenant1: Events fetch error: 400 BAD REQUEST"
         )
         self.assertEqual(
-            log.output, [
-                f"WARNING:{LOGNAME}:tenant1: Events fetch error: "
-                f"400 BAD REQUEST"
-            ]
+            log.output, [f"WARNING:{LOGNAME}:tenant1: Events fetch error: 400 BAD REQUEST"]
         )
 
     @patch("argo_scg.sensu.Sensu._delete_silenced_entry")
@@ -5601,243 +4512,197 @@ class SensuEventsTests(unittest.TestCase):
         with self.assertLogs(LOGNAME) as log:
             self.sensu._delete_events(
                 events={
-                    "argo.ni4os.eu": [
-                        "generic.tcp.connect",
-                        "generic.http.connect"
-                    ],
-                    "argo-devel.ni4os.eu": ["generic.certificate.validation"]
+                    "argo.ni4os.eu": ["generic.tcp.connect", "generic.http.connect"],
+                    "argo-devel.ni4os.eu": ["generic.certificate.validation"],
                 },
-                namespace="tenant1"
+                namespace="tenant1",
             )
         self.assertEqual(mock_delete.call_count, 3)
-        mock_delete.assert_has_calls([
-            call(
-                "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant1/"
-                "events/argo.ni4os.eu/generic.tcp.connect",
-                headers={
-                    "Authorization": "Key t0k3n"
-                }
-            ),
-            call(
-                "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant1/"
-                "events/argo.ni4os.eu/generic.http.connect",
-                headers={
-                    "Authorization": "Key t0k3n"
-                }
-            ),
-            call(
-                "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant1/"
-                "events/argo-devel.ni4os.eu/generic.certificate.validation",
-                headers={
-                    "Authorization": "Key t0k3n"
-                }
-            )
-        ], any_order=True)
+        mock_delete.assert_has_calls(
+            [
+                call(
+                    "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant1/"
+                    "events/argo.ni4os.eu/generic.tcp.connect",
+                    headers={"Authorization": "Key t0k3n"},
+                ),
+                call(
+                    "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant1/"
+                    "events/argo.ni4os.eu/generic.http.connect",
+                    headers={"Authorization": "Key t0k3n"},
+                ),
+                call(
+                    "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant1/"
+                    "events/argo-devel.ni4os.eu/generic.certificate.validation",
+                    headers={"Authorization": "Key t0k3n"},
+                ),
+            ],
+            any_order=True,
+        )
         self.assertEqual(mock_delete_silenced.call_count, 3)
-        mock_delete_silenced.assert_has_calls([
-            call(
-                entity="argo.ni4os.eu",
-                check="generic.tcp.connect",
-                namespace="tenant1"
-            ),
-            call(
-                entity="argo.ni4os.eu",
-                check="generic.http.connect",
-                namespace="tenant1"
-            ),
-            call(
-                entity="argo-devel.ni4os.eu",
-                check="generic.certificate.validation",
-                namespace="tenant1"
-            )
-        ], any_order=True)
+        mock_delete_silenced.assert_has_calls(
+            [
+                call(entity="argo.ni4os.eu", check="generic.tcp.connect", namespace="tenant1"),
+                call(entity="argo.ni4os.eu", check="generic.http.connect", namespace="tenant1"),
+                call(
+                    entity="argo-devel.ni4os.eu",
+                    check="generic.certificate.validation",
+                    namespace="tenant1",
+                ),
+            ],
+            any_order=True,
+        )
         self.assertEqual(
-            set(log.output), {
+            set(log.output),
+            {
                 f"INFO:{LOGNAME}:tenant1: Event "
                 f"argo-devel.ni4os.eu/generic.certificate.validation removed",
-                f"INFO:{LOGNAME}:tenant1: Event "
-                f"argo.ni4os.eu/generic.http.connect removed",
-                f"INFO:{LOGNAME}:tenant1: Event "
-                f"argo.ni4os.eu/generic.tcp.connect removed"
-            }
+                f"INFO:{LOGNAME}:tenant1: Event argo.ni4os.eu/generic.http.connect removed",
+                f"INFO:{LOGNAME}:tenant1: Event argo.ni4os.eu/generic.tcp.connect removed",
+            },
         )
 
     @patch("argo_scg.sensu.Sensu._delete_silenced_entry")
     @patch("requests.delete")
-    def test_delete_events_with_error_with_message(
-            self, mock_delete, mock_delete_silenced
-    ):
+    def test_delete_events_with_error_with_message(self, mock_delete, mock_delete_silenced):
         mock_delete.side_effect = [
             MockResponse(None, status_code=204),
-            MockResponse({"message": "Something went wrong."}, status_code=400)
+            MockResponse({"message": "Something went wrong."}, status_code=400),
         ]
         mock_delete_silenced.side_effect = mock_function
         with self.assertLogs(LOGNAME) as log:
             self.sensu._delete_events(
-                events={
-                    "argo.ni4os.eu": [
-                        "generic.tcp.connect",
-                        "generic.http.connect"
-                    ]
-                },
-                namespace="tenant1"
+                events={"argo.ni4os.eu": ["generic.tcp.connect", "generic.http.connect"]},
+                namespace="tenant1",
             )
         self.assertEqual(mock_delete.call_count, 2)
-        mock_delete.assert_has_calls([
-            call(
-                "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant1/"
-                "events/argo.ni4os.eu/generic.tcp.connect",
-                headers={
-                    "Authorization": "Key t0k3n"
-                }
-            ),
-            call(
-                "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant1/"
-                "events/argo.ni4os.eu/generic.http.connect",
-                headers={
-                    "Authorization": "Key t0k3n"
-                }
-            )
-        ], any_order=True)
+        mock_delete.assert_has_calls(
+            [
+                call(
+                    "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant1/"
+                    "events/argo.ni4os.eu/generic.tcp.connect",
+                    headers={"Authorization": "Key t0k3n"},
+                ),
+                call(
+                    "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant1/"
+                    "events/argo.ni4os.eu/generic.http.connect",
+                    headers={"Authorization": "Key t0k3n"},
+                ),
+            ],
+            any_order=True,
+        )
         mock_delete_silenced.assert_called_once_with(
-            entity="argo.ni4os.eu",
-            check="generic.tcp.connect",
-            namespace="tenant1"
+            entity="argo.ni4os.eu", check="generic.tcp.connect", namespace="tenant1"
         )
         self.assertEqual(
-            set(log.output), {
-                f"INFO:{LOGNAME}:tenant1: Event "
-                f"argo.ni4os.eu/generic.tcp.connect removed",
+            set(log.output),
+            {
+                f"INFO:{LOGNAME}:tenant1: Event argo.ni4os.eu/generic.tcp.connect removed",
                 f"WARNING:{LOGNAME}:tenant1: Event "
                 f"argo.ni4os.eu/generic.http.connect not removed: "
-                f"400 BAD REQUEST: Something went wrong."
-            }
+                f"400 BAD REQUEST: Something went wrong.",
+            },
         )
 
     @patch("argo_scg.sensu.Sensu._delete_silenced_entry")
     @patch("requests.delete")
-    def test_delete_events_with_error_without_message(
-            self, mock_delete, mock_delete_silenced
-    ):
+    def test_delete_events_with_error_without_message(self, mock_delete, mock_delete_silenced):
         mock_delete.side_effect = [
             MockResponse(None, status_code=204),
-            MockResponse(None, status_code=400)
+            MockResponse(None, status_code=400),
         ]
         mock_delete_silenced.side_effect = mock_function
         with self.assertLogs(LOGNAME) as log:
             self.sensu._delete_events(
-                events={
-                    "argo.ni4os.eu": [
-                        "generic.tcp.connect",
-                        "generic.http.connect"
-                    ]
-                },
-                namespace="tenant1"
+                events={"argo.ni4os.eu": ["generic.tcp.connect", "generic.http.connect"]},
+                namespace="tenant1",
             )
         self.assertEqual(mock_delete.call_count, 2)
-        mock_delete.assert_has_calls([
-            call(
-                "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant1/"
-                "events/argo.ni4os.eu/generic.tcp.connect",
-                headers={
-                    "Authorization": "Key t0k3n"
-                }
-            ),
-            call(
-                "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant1/"
-                "events/argo.ni4os.eu/generic.http.connect",
-                headers={
-                    "Authorization": "Key t0k3n"
-                }
-            )
-        ], any_order=True)
+        mock_delete.assert_has_calls(
+            [
+                call(
+                    "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant1/"
+                    "events/argo.ni4os.eu/generic.tcp.connect",
+                    headers={"Authorization": "Key t0k3n"},
+                ),
+                call(
+                    "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant1/"
+                    "events/argo.ni4os.eu/generic.http.connect",
+                    headers={"Authorization": "Key t0k3n"},
+                ),
+            ],
+            any_order=True,
+        )
         mock_delete_silenced.assert_called_once_with(
-            entity="argo.ni4os.eu",
-            check="generic.tcp.connect",
-            namespace="tenant1"
+            entity="argo.ni4os.eu", check="generic.tcp.connect", namespace="tenant1"
         )
         self.assertEqual(
-            set(log.output), {
-                f"INFO:{LOGNAME}:tenant1: Event "
-                f"argo.ni4os.eu/generic.tcp.connect removed",
+            set(log.output),
+            {
+                f"INFO:{LOGNAME}:tenant1: Event argo.ni4os.eu/generic.tcp.connect removed",
                 f"WARNING:{LOGNAME}:tenant1: Event "
                 f"argo.ni4os.eu/generic.http.connect not removed: "
-                f"400 BAD REQUEST"
-            }
+                f"400 BAD REQUEST",
+            },
         )
 
     @patch("argo_scg.sensu.Sensu._delete_silenced_entry")
     @patch("requests.delete")
-    def test_delete_events_with_silenced_entry_error(
-            self, mock_delete, mock_delete_silenced
-    ):
+    def test_delete_events_with_silenced_entry_error(self, mock_delete, mock_delete_silenced):
         mock_delete.side_effect = mock_delete_response
         mock_delete_silenced.side_effect = mock_silenced_entry_delete_exception
         with self.assertLogs(LOGNAME) as log:
             self.sensu._delete_events(
                 events={
-                    "argo.ni4os.eu": [
-                        "generic.tcp.connect",
-                        "generic.http.connect"
-                    ],
-                    "argo-devel.ni4os.eu": ["generic.certificate.validation"]
+                    "argo.ni4os.eu": ["generic.tcp.connect", "generic.http.connect"],
+                    "argo-devel.ni4os.eu": ["generic.certificate.validation"],
                 },
-                namespace="tenant1"
+                namespace="tenant1",
             )
         self.assertEqual(mock_delete.call_count, 3)
-        mock_delete.assert_has_calls([
-            call(
-                "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant1/"
-                "events/argo.ni4os.eu/generic.tcp.connect",
-                headers={
-                    "Authorization": "Key t0k3n"
-                }
-            ),
-            call(
-                "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant1/"
-                "events/argo.ni4os.eu/generic.http.connect",
-                headers={
-                    "Authorization": "Key t0k3n"
-                }
-            ),
-            call(
-                "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant1/"
-                "events/argo-devel.ni4os.eu/generic.certificate.validation",
-                headers={
-                    "Authorization": "Key t0k3n"
-                }
-            )
-        ], any_order=True)
+        mock_delete.assert_has_calls(
+            [
+                call(
+                    "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant1/"
+                    "events/argo.ni4os.eu/generic.tcp.connect",
+                    headers={"Authorization": "Key t0k3n"},
+                ),
+                call(
+                    "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant1/"
+                    "events/argo.ni4os.eu/generic.http.connect",
+                    headers={"Authorization": "Key t0k3n"},
+                ),
+                call(
+                    "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant1/"
+                    "events/argo-devel.ni4os.eu/generic.certificate.validation",
+                    headers={"Authorization": "Key t0k3n"},
+                ),
+            ],
+            any_order=True,
+        )
         self.assertEqual(mock_delete_silenced.call_count, 3)
-        mock_delete_silenced.assert_has_calls([
-            call(
-                entity="argo.ni4os.eu",
-                check="generic.tcp.connect",
-                namespace="tenant1"
-            ),
-            call(
-                entity="argo.ni4os.eu",
-                check="generic.http.connect",
-                namespace="tenant1"
-            ),
-            call(
-                entity="argo-devel.ni4os.eu",
-                check="generic.certificate.validation",
-                namespace="tenant1"
-            )
-        ], any_order=True)
+        mock_delete_silenced.assert_has_calls(
+            [
+                call(entity="argo.ni4os.eu", check="generic.tcp.connect", namespace="tenant1"),
+                call(entity="argo.ni4os.eu", check="generic.http.connect", namespace="tenant1"),
+                call(
+                    entity="argo-devel.ni4os.eu",
+                    check="generic.certificate.validation",
+                    namespace="tenant1",
+                ),
+            ],
+            any_order=True,
+        )
         self.assertEqual(
-            set(log.output), {
+            set(log.output),
+            {
                 f"INFO:{LOGNAME}:tenant1: Event "
                 f"argo-devel.ni4os.eu/generic.certificate.validation removed",
-                f"INFO:{LOGNAME}:tenant1: Event "
-                f"argo.ni4os.eu/generic.http.connect removed",
-                f"INFO:{LOGNAME}:tenant1: Event "
-                f"argo.ni4os.eu/generic.tcp.connect removed",
+                f"INFO:{LOGNAME}:tenant1: Event argo.ni4os.eu/generic.http.connect removed",
+                f"INFO:{LOGNAME}:tenant1: Event argo.ni4os.eu/generic.tcp.connect removed",
                 f"WARNING:{LOGNAME}:tenant1: Silenced entry "
                 f"entity:argo.ni4os.eu:generic.tcp.connect "
-                "(400 BAD REQUEST: Something went wrong) not removed"
-            }
+                "(400 BAD REQUEST: Something went wrong) not removed",
+            },
         )
 
     @patch("argo_scg.sensu.Sensu._delete_silenced_entry")
@@ -5846,122 +4711,94 @@ class SensuEventsTests(unittest.TestCase):
         mock_delete.side_effect = mock_delete_response
         mock_delete_silenced.side_effect = mock_function
         self.sensu.delete_event(
-            entity="argo.ni4os.eu",
-            check="generic.tcp.connect",
-            namespace="tenant1"
+            entity="argo.ni4os.eu", check="generic.tcp.connect", namespace="tenant1"
         )
         mock_delete.assert_called_once_with(
             "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant1/events/"
             "argo.ni4os.eu/generic.tcp.connect",
-            headers={
-                "Authorization": "Key t0k3n"
-            }
+            headers={"Authorization": "Key t0k3n"},
         )
         mock_delete_silenced.called_once_with(
-            entity="argo.ni4os.eu",
-            check="generic.tcp.connect",
-            namespace="tenant1"
+            entity="argo.ni4os.eu", check="generic.tcp.connect", namespace="tenant1"
         )
 
     @patch("argo_scg.sensu.Sensu._delete_silenced_entry")
     @patch("requests.delete")
-    def test_delete_event_with_error_with_message(
-            self, mock_delete, mock_delete_silenced
-    ):
+    def test_delete_event_with_error_with_message(self, mock_delete, mock_delete_silenced):
         mock_delete.return_value = MockResponse(
             {"message": "Something went wrong"}, status_code=400
         )
         mock_delete_silenced.side_effect = mock_function
         with self.assertRaises(SensuException) as context:
             self.sensu.delete_event(
-                entity="argo.ni4os.eu",
-                check="generic.tcp.connect",
-                namespace="tenant1"
+                entity="argo.ni4os.eu", check="generic.tcp.connect", namespace="tenant1"
             )
         mock_delete.assert_called_once_with(
             "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant1/events/"
             "argo.ni4os.eu/generic.tcp.connect",
-            headers={
-                "Authorization": "Key t0k3n"
-            }
+            headers={"Authorization": "Key t0k3n"},
         )
         self.assertFalse(mock_delete_silenced.called)
         self.assertEqual(
             context.exception.__str__(),
             "Sensu error: tenant1: Event argo.ni4os.eu/generic.tcp.connect not "
-            "removed: 400 BAD REQUEST: Something went wrong"
+            "removed: 400 BAD REQUEST: Something went wrong",
         )
 
     @patch("argo_scg.sensu.Sensu._delete_silenced_entry")
     @patch("requests.delete")
-    def test_delete_event_with_error_without_message(
-            self, mock_delete, mock_delete_silenced
-    ):
+    def test_delete_event_with_error_without_message(self, mock_delete, mock_delete_silenced):
         mock_delete.return_value = MockResponse(None, status_code=400)
         mock_delete_silenced.side_effect = mock_function
         with self.assertRaises(SensuException) as context:
             self.sensu.delete_event(
-                entity="argo.ni4os.eu",
-                check="generic.tcp.connect",
-                namespace="tenant1"
+                entity="argo.ni4os.eu", check="generic.tcp.connect", namespace="tenant1"
             )
         mock_delete.assert_called_once_with(
             "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant1/events/"
             "argo.ni4os.eu/generic.tcp.connect",
-            headers={
-                "Authorization": "Key t0k3n"
-            }
+            headers={"Authorization": "Key t0k3n"},
         )
         self.assertFalse(mock_delete_silenced.called)
         self.assertEqual(
             context.exception.__str__(),
             "Sensu error: tenant1: Event argo.ni4os.eu/generic.tcp.connect not "
-            "removed: 400 BAD REQUEST"
+            "removed: 400 BAD REQUEST",
         )
 
     @patch("argo_scg.sensu.Sensu._delete_silenced_entry")
     @patch("requests.delete")
-    def test_delete_event_with_silenced_entry_error(
-            self, mock_delete, mock_delete_silenced
-    ):
+    def test_delete_event_with_silenced_entry_error(self, mock_delete, mock_delete_silenced):
         mock_delete.side_effect = mock_delete_response
         mock_delete_silenced.side_effect = mock_silenced_entry_delete_exception
         with self.assertRaises(SCGWarnException) as context:
             self.sensu.delete_event(
-                entity="argo.ni4os.eu",
-                check="generic.tcp.connect",
-                namespace="tenant1"
+                entity="argo.ni4os.eu", check="generic.tcp.connect", namespace="tenant1"
             )
         mock_delete.assert_called_once_with(
             "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant1/events/"
             "argo.ni4os.eu/generic.tcp.connect",
-            headers={
-                "Authorization": "Key t0k3n"
-            }
+            headers={"Authorization": "Key t0k3n"},
         )
         mock_delete_silenced.called_once_with(
-            entity="argo.ni4os.eu",
-            check="generic.tcp.connect",
-            namespace="tenant1"
+            entity="argo.ni4os.eu", check="generic.tcp.connect", namespace="tenant1"
         )
         self.assertEqual(
             context.exception.__str__(),
             "Silenced entry entity:argo.ni4os.eu:generic.tcp.connect "
-            "(400 BAD REQUEST: Something went wrong) not removed"
+            "(400 BAD REQUEST: Something went wrong) not removed",
         )
 
     @patch("requests.get")
     def test_get_event_output(self, mock_get):
         mock_get.side_effect = mock_sensu_request
         output = self.sensu.get_event_output(
-            entity="gocdb.ni4os.eu",
-            check="generic.tcp.connect",
-            namespace="tenant1"
+            entity="gocdb.ni4os.eu", check="generic.tcp.connect", namespace="tenant1"
         )
         self.assertEqual(
             output,
             "TCP OK - 0.045 second response time on gocdb.ni4os.eu port 443|"
-            "time=0.044729s;;;0.000000;120.000000\n"
+            "time=0.044729s;;;0.000000;120.000000\n",
         )
 
     @patch("requests.get")
@@ -5969,15 +4806,12 @@ class SensuEventsTests(unittest.TestCase):
         mock_get.side_effect = mock_sensu_request_events_not_ok_with_msg
         with self.assertRaises(SensuException) as context:
             self.sensu.get_event_output(
-                entity="gocdb.ni4os.eu",
-                check="generic.tcp.connect",
-                namespace="tenant1"
+                entity="gocdb.ni4os.eu", check="generic.tcp.connect", namespace="tenant1"
             )
 
         self.assertEqual(
             context.exception.__str__(),
-            "Sensu error: tenant1: Events fetch error: 400 BAD REQUEST: "
-            "Something went wrong."
+            "Sensu error: tenant1: Events fetch error: 400 BAD REQUEST: Something went wrong.",
         )
 
     @patch("requests.get")
@@ -5985,14 +4819,11 @@ class SensuEventsTests(unittest.TestCase):
         mock_get.side_effect = mock_sensu_request_events_not_ok_without_msg
         with self.assertRaises(SensuException) as context:
             self.sensu.get_event_output(
-                entity="gocdb.ni4os.eu",
-                check="generic.tcp.connect",
-                namespace="tenant1"
+                entity="gocdb.ni4os.eu", check="generic.tcp.connect", namespace="tenant1"
             )
 
         self.assertEqual(
-            context.exception.__str__(),
-            "Sensu error: tenant1: Events fetch error: 400 BAD REQUEST"
+            context.exception.__str__(), "Sensu error: tenant1: Events fetch error: 400 BAD REQUEST"
         )
 
     @patch("requests.get")
@@ -6000,15 +4831,13 @@ class SensuEventsTests(unittest.TestCase):
         mock_get.side_effect = mock_sensu_request
         with self.assertRaises(SensuException) as context:
             self.sensu.get_event_output(
-                entity="mock.entity.com",
-                check="generic.tcp.connect",
-                namespace="tenant1"
+                entity="mock.entity.com", check="generic.tcp.connect", namespace="tenant1"
             )
 
         self.assertEqual(
             context.exception.__str__(),
             "Sensu error: tenant1: No event for entity mock.entity.com and "
-            "check generic.tcp.connect"
+            "check generic.tcp.connect",
         )
 
 
@@ -6017,11 +4846,7 @@ class SensuEntityTests(unittest.TestCase):
         self.sensu = Sensu(
             url="https://sensu.mock.com:8080",
             token="t0k3n",
-            namespaces={
-                "default": ["default"],
-                "tenant1": ["TENANT1"],
-                "tenant2": ["TENANT2"]
-            }
+            namespaces={"default": ["default"], "tenant1": ["TENANT1"], "tenant2": ["TENANT2"]},
         )
         self.entities = [
             {
@@ -6030,16 +4855,14 @@ class SensuEntityTests(unittest.TestCase):
                     "name": "argo-devel.ni4os.eu",
                     "namespace": "tenant1",
                     "labels": {
-                        "generic_http_ar_argoui_ni4os":
-                            "generic.http.ar-argoui-ni4os",
+                        "generic_http_ar_argoui_ni4os": "generic.http.ar-argoui-ni4os",
                         "generic_http_connect": "generic.http.connect",
-                        "generic_certificate_validity":
-                            "generic.certificate.validity",
+                        "generic_certificate_validity": "generic.certificate.validity",
                         "generic_tcp_connect": "generic.tcp.connect",
                         "hostname": "argo-devel.ni4os.eu",
-                        "tenants": "TENANT1"
+                        "tenants": "TENANT1",
                     },
-                }
+                },
             },
             {
                 "entity_class": "proxy",
@@ -6049,9 +4872,9 @@ class SensuEntityTests(unittest.TestCase):
                     "labels": {
                         "generic_http_connect": "generic.http.connect",
                         "hostname": "argo.ni4os.eu",
-                        "tenants": "TENANT1"
-                    }
-                }
+                        "tenants": "TENANT1",
+                    },
+                },
             },
             {
                 "entity_class": "proxy",
@@ -6061,10 +4884,10 @@ class SensuEntityTests(unittest.TestCase):
                     "labels": {
                         "generic_tcp_connect": "generic.tcp.connect",
                         "hostname": "argo-mon.ni4os.eu",
-                        "tenants": "TENANT1"
-                    }
-                }
-            }
+                        "tenants": "TENANT1",
+                    },
+                },
+            },
         ]
 
     @patch("requests.get")
@@ -6074,17 +4897,10 @@ class SensuEntityTests(unittest.TestCase):
             _log_dummy()
             entities = self.sensu._get_proxy_entities(namespace="tenant1")
         mock_get.assert_called_once_with(
-            "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant1/"
-            "entities",
-            headers={
-                "Authorization": "Key t0k3n",
-                "Content-Type": "application/json"
-            }
+            "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant1/entities",
+            headers={"Authorization": "Key t0k3n", "Content-Type": "application/json"},
         )
-        self.assertEqual(
-            sorted(entities, key=lambda k: k["metadata"]["name"]),
-            mock_entities[:-2]
-        )
+        self.assertEqual(sorted(entities, key=lambda k: k["metadata"]["name"]), mock_entities[:-2])
         self.assertEqual(log.output, DUMMY_LOG)
 
     @patch("requests.get")
@@ -6095,24 +4911,21 @@ class SensuEntityTests(unittest.TestCase):
                 self.sensu._get_proxy_entities(namespace="tenant1")
 
         mock_get.assert_called_once_with(
-            "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant1/"
-            "entities",
-            headers={
-                "Authorization": "Key t0k3n",
-                "Content-Type": "application/json"
-            }
+            "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant1/entities",
+            headers={"Authorization": "Key t0k3n", "Content-Type": "application/json"},
         )
 
         self.assertEqual(
             context.exception.__str__(),
             "Sensu error: tenant1: Error fetching proxy entities: "
-            "400 BAD REQUEST: Something went wrong."
+            "400 BAD REQUEST: Something went wrong.",
         )
         self.assertEqual(
-            log.output, [
+            log.output,
+            [
                 f"ERROR:{LOGNAME}:tenant1: Error fetching proxy entities: "
                 f"400 BAD REQUEST: Something went wrong."
-            ]
+            ],
         )
 
     @patch("requests.get")
@@ -6123,24 +4936,16 @@ class SensuEntityTests(unittest.TestCase):
                 self.sensu._get_proxy_entities(namespace="tenant1")
 
         mock_get.assert_called_once_with(
-            "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant1/"
-            "entities",
-            headers={
-                "Authorization": "Key t0k3n",
-                "Content-Type": "application/json"
-            }
+            "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant1/entities",
+            headers={"Authorization": "Key t0k3n", "Content-Type": "application/json"},
         )
 
         self.assertEqual(
             context.exception.__str__(),
-            "Sensu error: tenant1: Error fetching proxy entities: "
-            "400 BAD REQUEST"
+            "Sensu error: tenant1: Error fetching proxy entities: 400 BAD REQUEST",
         )
         self.assertEqual(
-            log.output, [
-                f"ERROR:{LOGNAME}:tenant1: Error fetching proxy entities: "
-                f"400 BAD REQUEST"
-            ]
+            log.output, [f"ERROR:{LOGNAME}:tenant1: Error fetching proxy entities: 400 BAD REQUEST"]
         )
 
     @patch("argo_scg.sensu.Sensu._delete_silenced_entry")
@@ -6152,462 +4957,429 @@ class SensuEntityTests(unittest.TestCase):
         with self.assertLogs(LOGNAME) as log:
             self.sensu._delete_entities(entities=entities, namespace="tenant1")
         self.assertEqual(mock_delete.call_count, 3)
-        mock_delete.assert_has_calls([
-            call(
-                "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant1/"
-                "entities/argo.ni4os.eu",
-                headers={
-                    "Authorization": "Key t0k3n"
-                }
-            ),
-            call(
-                "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant1/"
-                "entities/argo-devel.ni4os.eu",
-                headers={
-                    "Authorization": "Key t0k3n"
-                }
-            ),
-            call(
-                "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant1/"
-                "entities/gocdb.ni4os.eu",
-                headers={
-                    "Authorization": "Key t0k3n"
-                }
-            )
-        ], any_order=True)
+        mock_delete.assert_has_calls(
+            [
+                call(
+                    "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant1/"
+                    "entities/argo.ni4os.eu",
+                    headers={"Authorization": "Key t0k3n"},
+                ),
+                call(
+                    "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant1/"
+                    "entities/argo-devel.ni4os.eu",
+                    headers={"Authorization": "Key t0k3n"},
+                ),
+                call(
+                    "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant1/"
+                    "entities/gocdb.ni4os.eu",
+                    headers={"Authorization": "Key t0k3n"},
+                ),
+            ],
+            any_order=True,
+        )
         self.assertEqual(mock_delete_silenced.call_count, 3)
-        mock_delete_silenced.assert_has_calls([
-            call(entity="argo.ni4os.eu", namespace="tenant1"),
-            call(entity="argo-devel.ni4os.eu", namespace="tenant1"),
-            call(entity="gocdb.ni4os.eu", namespace="tenant1")
-        ], any_order=True)
+        mock_delete_silenced.assert_has_calls(
+            [
+                call(entity="argo.ni4os.eu", namespace="tenant1"),
+                call(entity="argo-devel.ni4os.eu", namespace="tenant1"),
+                call(entity="gocdb.ni4os.eu", namespace="tenant1"),
+            ],
+            any_order=True,
+        )
         self.assertEqual(
-            set(log.output), {
+            set(log.output),
+            {
                 f"INFO:{LOGNAME}:tenant1: Entity argo.ni4os.eu removed",
                 f"INFO:{LOGNAME}:tenant1: Entity argo-devel.ni4os.eu removed",
-                f"INFO:{LOGNAME}:tenant1: Entity gocdb.ni4os.eu removed"
-            }
+                f"INFO:{LOGNAME}:tenant1: Entity gocdb.ni4os.eu removed",
+            },
         )
 
     @patch("argo_scg.sensu.Sensu._delete_silenced_entry")
     @patch("requests.delete")
-    def test_delete_entities_with_error_with_message(
-            self, mock_delete, mock_delete_silenced
-    ):
+    def test_delete_entities_with_error_with_message(self, mock_delete, mock_delete_silenced):
         mock_delete.side_effect = [
             MockResponse(None, status_code=204),
             MockResponse({"message": "Something went wrong."}, status_code=400),
-            MockResponse(None, status_code=204)
+            MockResponse(None, status_code=204),
         ]
         mock_delete_silenced.side_effect = mock_function
         entities = ["argo.ni4os.eu", "argo-devel.ni4os.eu", "gocdb.ni4os.eu"]
         with self.assertLogs(LOGNAME) as log:
             self.sensu._delete_entities(entities=entities, namespace="tenant1")
         self.assertEqual(mock_delete.call_count, 3)
-        mock_delete.assert_has_calls([
-            call(
-                "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant1/"
-                "entities/argo.ni4os.eu",
-                headers={
-                    "Authorization": "Key t0k3n"
-                }
-            ),
-            call(
-                "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant1/"
-                "entities/argo-devel.ni4os.eu",
-                headers={
-                    "Authorization": "Key t0k3n"
-                }
-            ),
-            call(
-                "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant1/"
-                "entities/gocdb.ni4os.eu",
-                headers={
-                    "Authorization": "Key t0k3n"
-                }
-            )
-        ], any_order=True)
+        mock_delete.assert_has_calls(
+            [
+                call(
+                    "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant1/"
+                    "entities/argo.ni4os.eu",
+                    headers={"Authorization": "Key t0k3n"},
+                ),
+                call(
+                    "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant1/"
+                    "entities/argo-devel.ni4os.eu",
+                    headers={"Authorization": "Key t0k3n"},
+                ),
+                call(
+                    "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant1/"
+                    "entities/gocdb.ni4os.eu",
+                    headers={"Authorization": "Key t0k3n"},
+                ),
+            ],
+            any_order=True,
+        )
         self.assertEqual(mock_delete_silenced.call_count, 2)
-        mock_delete_silenced.assert_has_calls([
-            call(entity="argo.ni4os.eu", namespace="tenant1"),
-            call(entity="gocdb.ni4os.eu", namespace="tenant1")
-        ], any_order=True)
+        mock_delete_silenced.assert_has_calls(
+            [
+                call(entity="argo.ni4os.eu", namespace="tenant1"),
+                call(entity="gocdb.ni4os.eu", namespace="tenant1"),
+            ],
+            any_order=True,
+        )
         self.assertEqual(
-            set(log.output), {
+            set(log.output),
+            {
                 f"INFO:{LOGNAME}:tenant1: Entity argo.ni4os.eu removed",
                 f"WARNING:{LOGNAME}:tenant1: Entity argo-devel.ni4os.eu "
                 f"not removed: 400 BAD REQUEST: Something went wrong.",
-                f"INFO:{LOGNAME}:tenant1: Entity gocdb.ni4os.eu removed"
-            }
+                f"INFO:{LOGNAME}:tenant1: Entity gocdb.ni4os.eu removed",
+            },
         )
 
     @patch("argo_scg.sensu.Sensu._delete_silenced_entry")
     @patch("requests.delete")
-    def test_delete_entities_with_error_without_message(
-            self, mock_delete, mock_delete_silenced
-    ):
+    def test_delete_entities_with_error_without_message(self, mock_delete, mock_delete_silenced):
         mock_delete.side_effect = [
             MockResponse(None, status_code=204),
             MockResponse(None, status_code=400),
-            MockResponse(None, status_code=204)
+            MockResponse(None, status_code=204),
         ]
         mock_delete_silenced.side_effect = mock_function
         entities = ["argo.ni4os.eu", "argo-devel.ni4os.eu", "gocdb.ni4os.eu"]
         with self.assertLogs(LOGNAME) as log:
             self.sensu._delete_entities(entities=entities, namespace="tenant1")
         self.assertEqual(mock_delete.call_count, 3)
-        mock_delete.assert_has_calls([
-            call(
-                "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant1/"
-                "entities/argo.ni4os.eu",
-                headers={
-                    "Authorization": "Key t0k3n"
-                }
-            ),
-            call(
-                "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant1/"
-                "entities/argo-devel.ni4os.eu",
-                headers={
-                    "Authorization": "Key t0k3n"
-                }
-            ),
-            call(
-                "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant1/"
-                "entities/gocdb.ni4os.eu",
-                headers={
-                    "Authorization": "Key t0k3n"
-                }
-            )
-        ], any_order=True)
+        mock_delete.assert_has_calls(
+            [
+                call(
+                    "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant1/"
+                    "entities/argo.ni4os.eu",
+                    headers={"Authorization": "Key t0k3n"},
+                ),
+                call(
+                    "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant1/"
+                    "entities/argo-devel.ni4os.eu",
+                    headers={"Authorization": "Key t0k3n"},
+                ),
+                call(
+                    "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant1/"
+                    "entities/gocdb.ni4os.eu",
+                    headers={"Authorization": "Key t0k3n"},
+                ),
+            ],
+            any_order=True,
+        )
         self.assertEqual(mock_delete_silenced.call_count, 2)
-        mock_delete_silenced.assert_has_calls([
-            call(entity="argo.ni4os.eu", namespace="tenant1"),
-            call(entity="gocdb.ni4os.eu", namespace="tenant1")
-        ], any_order=True)
+        mock_delete_silenced.assert_has_calls(
+            [
+                call(entity="argo.ni4os.eu", namespace="tenant1"),
+                call(entity="gocdb.ni4os.eu", namespace="tenant1"),
+            ],
+            any_order=True,
+        )
         self.assertEqual(
-            set(log.output), {
+            set(log.output),
+            {
                 f"INFO:{LOGNAME}:tenant1: Entity argo.ni4os.eu removed",
                 f"WARNING:{LOGNAME}:tenant1: Entity argo-devel.ni4os.eu not "
                 f"removed: 400 BAD REQUEST",
-                f"INFO:{LOGNAME}:tenant1: Entity gocdb.ni4os.eu removed"
-            }
+                f"INFO:{LOGNAME}:tenant1: Entity gocdb.ni4os.eu removed",
+            },
         )
 
     @patch("argo_scg.sensu.Sensu._delete_silenced_entry")
     @patch("requests.delete")
-    def test_delete_entities_with_silenced_entry_error(
-            self, mock_delete, mock_delete_silenced
-    ):
+    def test_delete_entities_with_silenced_entry_error(self, mock_delete, mock_delete_silenced):
         mock_delete.side_effect = mock_delete_response
         mock_delete_silenced.side_effect = mock_silenced_entry_delete_exception
         entities = ["argo.ni4os.eu", "argo-devel.ni4os.eu", "gocdb.ni4os.eu"]
         with self.assertLogs(LOGNAME) as log:
             self.sensu._delete_entities(entities=entities, namespace="tenant1")
         self.assertEqual(mock_delete.call_count, 3)
-        mock_delete.assert_has_calls([
-            call(
-                "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant1/"
-                "entities/argo.ni4os.eu",
-                headers={
-                    "Authorization": "Key t0k3n"
-                }
-            ),
-            call(
-                "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant1/"
-                "entities/argo-devel.ni4os.eu",
-                headers={
-                    "Authorization": "Key t0k3n"
-                }
-            ),
-            call(
-                "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant1/"
-                "entities/gocdb.ni4os.eu",
-                headers={
-                    "Authorization": "Key t0k3n"
-                }
-            )
-        ], any_order=True)
+        mock_delete.assert_has_calls(
+            [
+                call(
+                    "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant1/"
+                    "entities/argo.ni4os.eu",
+                    headers={"Authorization": "Key t0k3n"},
+                ),
+                call(
+                    "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant1/"
+                    "entities/argo-devel.ni4os.eu",
+                    headers={"Authorization": "Key t0k3n"},
+                ),
+                call(
+                    "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant1/"
+                    "entities/gocdb.ni4os.eu",
+                    headers={"Authorization": "Key t0k3n"},
+                ),
+            ],
+            any_order=True,
+        )
         self.assertEqual(mock_delete_silenced.call_count, 3)
-        mock_delete_silenced.assert_has_calls([
-            call(entity="argo.ni4os.eu", namespace="tenant1"),
-            call(entity="argo-devel.ni4os.eu", namespace="tenant1"),
-            call(entity="gocdb.ni4os.eu", namespace="tenant1")
-        ], any_order=True)
+        mock_delete_silenced.assert_has_calls(
+            [
+                call(entity="argo.ni4os.eu", namespace="tenant1"),
+                call(entity="argo-devel.ni4os.eu", namespace="tenant1"),
+                call(entity="gocdb.ni4os.eu", namespace="tenant1"),
+            ],
+            any_order=True,
+        )
         self.assertEqual(
-            set(log.output), {
+            set(log.output),
+            {
                 f"INFO:{LOGNAME}:tenant1: Entity argo.ni4os.eu removed",
                 f"INFO:{LOGNAME}:tenant1: Entity argo-devel.ni4os.eu removed",
                 f"INFO:{LOGNAME}:tenant1: Entity gocdb.ni4os.eu removed",
                 f"WARNING:{LOGNAME}:tenant1: Silenced entry "
                 f"entity:argo.ni4os.eu:generic.tcp.connect (400 BAD REQUEST: "
-                f"Something went wrong) not removed"
-            }
+                f"Something went wrong) not removed",
+            },
         )
 
     @patch("requests.put")
     @patch("argo_scg.sensu.Sensu._delete_entities")
     @patch("argo_scg.sensu.Sensu._get_proxy_entities")
-    def test_handle_proxy_entities(
-            self, mock_get_entities, mock_delete_entities, mock_put
-    ):
+    def test_handle_proxy_entities(self, mock_get_entities, mock_delete_entities, mock_put):
         mock_get_entities.return_value = mock_entities[:-2]
         mock_delete_entities.side_effect = mock_delete_response
         mock_put.side_effect = mock_post_response
 
         with self.assertLogs(LOGNAME) as log:
-            self.sensu.handle_proxy_entities(
-                entities=self.entities, namespace="tenant1"
-            )
+            self.sensu.handle_proxy_entities(entities=self.entities, namespace="tenant1")
 
         mock_get_entities.assert_called_once_with(namespace="tenant1")
         self.assertEqual(mock_put.call_count, 2)
-        mock_put.assert_has_calls([
-            call(
-                "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant1/"
-                "entities/argo-devel.ni4os.eu",
-                data=json.dumps(self.entities[0]),
-                headers={
-                    "Authorization": "Key t0k3n",
-                    "Content-Type": "application/json"
-                }
-            ),
-            call(
-                "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant1/"
-                "entities/argo-mon.ni4os.eu",
-                data=json.dumps(self.entities[2]),
-                headers={
-                    "Authorization": "Key t0k3n",
-                    "Content-Type": "application/json"
-                }
-            )
-        ], any_order=True)
+        mock_put.assert_has_calls(
+            [
+                call(
+                    "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant1/"
+                    "entities/argo-devel.ni4os.eu",
+                    data=json.dumps(self.entities[0]),
+                    headers={"Authorization": "Key t0k3n", "Content-Type": "application/json"},
+                ),
+                call(
+                    "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant1/"
+                    "entities/argo-mon.ni4os.eu",
+                    data=json.dumps(self.entities[2]),
+                    headers={"Authorization": "Key t0k3n", "Content-Type": "application/json"},
+                ),
+            ],
+            any_order=True,
+        )
 
         mock_delete_entities.assert_called_once_with(
-            entities=["gocdb.ni4os.eu"],
-            namespace="tenant1"
+            entities=["gocdb.ni4os.eu"], namespace="tenant1"
         )
 
         self.assertEqual(
-            set(log.output), {
+            set(log.output),
+            {
                 f"INFO:{LOGNAME}:tenant1: Entity argo-mon.ni4os.eu created",
-                f"INFO:{LOGNAME}:tenant1: Entity argo-devel.ni4os.eu updated"
-            }
+                f"INFO:{LOGNAME}:tenant1: Entity argo-devel.ni4os.eu updated",
+            },
         )
 
     @patch("requests.put")
     @patch("argo_scg.sensu.Sensu._delete_entities")
     @patch("argo_scg.sensu.Sensu._get_proxy_entities")
     def test_handle_proxy_entities_if_different_labels(
-            self, mock_get_entities, mock_delete_entities, mock_put
+        self, mock_get_entities, mock_delete_entities, mock_put
     ):
-        copied_mock_entities = [
-            copy.deepcopy(item) for item in mock_entities[:-2]
-        ]
+        copied_mock_entities = [copy.deepcopy(item) for item in mock_entities[:-2]]
         copied_mock_entities[0]["metadata"]["labels"]["tenants"] = "TENANT2"
         mock_get_entities.return_value = copied_mock_entities
         mock_delete_entities.side_effect = mock_delete_response
         mock_put.side_effect = mock_post_response
 
         with self.assertLogs(LOGNAME) as log:
-            self.sensu.handle_proxy_entities(
-                entities=self.entities, namespace="tenant1"
-            )
+            self.sensu.handle_proxy_entities(entities=self.entities, namespace="tenant1")
 
         mock_get_entities.assert_called_once_with(namespace="tenant1")
         self.assertEqual(mock_put.call_count, 2)
-        mock_put.assert_has_calls([
-            call(
-                "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant1/"
-                "entities/argo-devel.ni4os.eu",
-                data=json.dumps(self.entities[0]),
-                headers={
-                    "Authorization": "Key t0k3n",
-                    "Content-Type": "application/json"
-                }
-            ),
-            call(
-                "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant1/"
-                "entities/argo-mon.ni4os.eu",
-                data=json.dumps(self.entities[2]),
-                headers={
-                    "Authorization": "Key t0k3n",
-                    "Content-Type": "application/json"
-                }
-            )
-        ], any_order=True)
+        mock_put.assert_has_calls(
+            [
+                call(
+                    "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant1/"
+                    "entities/argo-devel.ni4os.eu",
+                    data=json.dumps(self.entities[0]),
+                    headers={"Authorization": "Key t0k3n", "Content-Type": "application/json"},
+                ),
+                call(
+                    "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant1/"
+                    "entities/argo-mon.ni4os.eu",
+                    data=json.dumps(self.entities[2]),
+                    headers={"Authorization": "Key t0k3n", "Content-Type": "application/json"},
+                ),
+            ],
+            any_order=True,
+        )
 
         mock_delete_entities.assert_called_once_with(
-            entities=["gocdb.ni4os.eu"],
-            namespace="tenant1"
+            entities=["gocdb.ni4os.eu"], namespace="tenant1"
         )
 
         self.assertEqual(
-            set(log.output), {
+            set(log.output),
+            {
                 f"INFO:{LOGNAME}:tenant1: Entity argo-mon.ni4os.eu created",
-                f"INFO:{LOGNAME}:tenant1: Entity argo-devel.ni4os.eu updated"
-            }
+                f"INFO:{LOGNAME}:tenant1: Entity argo-devel.ni4os.eu updated",
+            },
         )
 
     @patch("requests.put")
     @patch("argo_scg.sensu.Sensu._delete_entities")
     @patch("argo_scg.sensu.Sensu._get_proxy_entities")
     def test_handle_proxy_entities_if_missing_labels(
-            self, mock_get_entities, mock_delete_entities, mock_put
+        self, mock_get_entities, mock_delete_entities, mock_put
     ):
-        copied_mock_entities = [
-            copy.deepcopy(item) for item in mock_entities[:-2]
-        ]
+        copied_mock_entities = [copy.deepcopy(item) for item in mock_entities[:-2]]
         copied_mock_entities[0]["metadata"]["labels"].pop("tenants")
         mock_get_entities.return_value = copied_mock_entities
         mock_delete_entities.side_effect = mock_delete_response
         mock_put.side_effect = mock_post_response
 
         with self.assertLogs(LOGNAME) as log:
-            self.sensu.handle_proxy_entities(
-                entities=self.entities, namespace="tenant1"
-            )
+            self.sensu.handle_proxy_entities(entities=self.entities, namespace="tenant1")
 
         mock_get_entities.assert_called_once_with(namespace="tenant1")
         self.assertEqual(mock_put.call_count, 2)
-        mock_put.assert_has_calls([
-            call(
-                "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant1/"
-                "entities/argo-devel.ni4os.eu",
-                data=json.dumps(self.entities[0]),
-                headers={
-                    "Authorization": "Key t0k3n",
-                    "Content-Type": "application/json"
-                }
-            ),
-            call(
-                "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant1/"
-                "entities/argo-mon.ni4os.eu",
-                data=json.dumps(self.entities[2]),
-                headers={
-                    "Authorization": "Key t0k3n",
-                    "Content-Type": "application/json"
-                }
-            )
-        ], any_order=True)
+        mock_put.assert_has_calls(
+            [
+                call(
+                    "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant1/"
+                    "entities/argo-devel.ni4os.eu",
+                    data=json.dumps(self.entities[0]),
+                    headers={"Authorization": "Key t0k3n", "Content-Type": "application/json"},
+                ),
+                call(
+                    "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant1/"
+                    "entities/argo-mon.ni4os.eu",
+                    data=json.dumps(self.entities[2]),
+                    headers={"Authorization": "Key t0k3n", "Content-Type": "application/json"},
+                ),
+            ],
+            any_order=True,
+        )
 
         mock_delete_entities.assert_called_once_with(
-            entities=["gocdb.ni4os.eu"],
-            namespace="tenant1"
+            entities=["gocdb.ni4os.eu"], namespace="tenant1"
         )
 
         self.assertEqual(
-            set(log.output), {
+            set(log.output),
+            {
                 f"INFO:{LOGNAME}:tenant1: Entity argo-mon.ni4os.eu created",
-                f"INFO:{LOGNAME}:tenant1: Entity argo-devel.ni4os.eu updated"
-            }
+                f"INFO:{LOGNAME}:tenant1: Entity argo-devel.ni4os.eu updated",
+            },
         )
 
     @patch("requests.put")
     @patch("argo_scg.sensu.Sensu._delete_entities")
     @patch("argo_scg.sensu.Sensu._get_proxy_entities")
     def test_handle_proxy_entities_with_error_with_msg(
-            self, mock_get_entities, mock_delete_entities, mock_put
+        self, mock_get_entities, mock_delete_entities, mock_put
     ):
         mock_get_entities.return_value = mock_entities[:-2]
         mock_delete_entities.side_effect = mock_delete_response
         mock_put.side_effect = [
             MockResponse(None, status_code=201),
-            MockResponse({"message": "Something went wrong."}, status_code=400)
+            MockResponse({"message": "Something went wrong."}, status_code=400),
         ]
 
         with self.assertLogs(LOGNAME) as log:
-            self.sensu.handle_proxy_entities(
-                entities=self.entities, namespace="tenant1"
-            )
+            self.sensu.handle_proxy_entities(entities=self.entities, namespace="tenant1")
 
         mock_get_entities.assert_called_once_with(namespace="tenant1")
         self.assertEqual(mock_put.call_count, 2)
-        mock_put.assert_has_calls([
-            call(
-                "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant1/"
-                "entities/argo-devel.ni4os.eu",
-                data=json.dumps(self.entities[0]),
-                headers={
-                    "Authorization": "Key t0k3n",
-                    "Content-Type": "application/json"
-                }
-            ),
-            call(
-                "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant1/"
-                "entities/argo-mon.ni4os.eu",
-                data=json.dumps(self.entities[2]),
-                headers={
-                    "Authorization": "Key t0k3n",
-                    "Content-Type": "application/json"
-                }
-            )
-        ], any_order=True)
+        mock_put.assert_has_calls(
+            [
+                call(
+                    "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant1/"
+                    "entities/argo-devel.ni4os.eu",
+                    data=json.dumps(self.entities[0]),
+                    headers={"Authorization": "Key t0k3n", "Content-Type": "application/json"},
+                ),
+                call(
+                    "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant1/"
+                    "entities/argo-mon.ni4os.eu",
+                    data=json.dumps(self.entities[2]),
+                    headers={"Authorization": "Key t0k3n", "Content-Type": "application/json"},
+                ),
+            ],
+            any_order=True,
+        )
 
         mock_delete_entities.assert_called_once_with(
-            entities=["gocdb.ni4os.eu"],
-            namespace="tenant1"
+            entities=["gocdb.ni4os.eu"], namespace="tenant1"
         )
 
         self.assertEqual(
-            set(log.output), {
+            set(log.output),
+            {
                 f"INFO:{LOGNAME}:tenant1: Entity argo-devel.ni4os.eu updated",
                 f"WARNING:{LOGNAME}:tenant1: Proxy entity argo-mon.ni4os.eu "
-                f"not created: 400 BAD REQUEST: Something went wrong."
-            }
+                f"not created: 400 BAD REQUEST: Something went wrong.",
+            },
         )
 
     @patch("requests.put")
     @patch("argo_scg.sensu.Sensu._delete_entities")
     @patch("argo_scg.sensu.Sensu._get_proxy_entities")
     def test_handle_proxy_entities_with_error_without_msg(
-            self, mock_get_entities, mock_delete_entities, mock_put
+        self, mock_get_entities, mock_delete_entities, mock_put
     ):
         mock_get_entities.return_value = mock_entities[:-2]
         mock_delete_entities.side_effect = mock_delete_response
         mock_put.side_effect = [
             MockResponse(None, status_code=201),
-            MockResponse(None, status_code=400)
+            MockResponse(None, status_code=400),
         ]
 
         with self.assertLogs(LOGNAME) as log:
-            self.sensu.handle_proxy_entities(
-                entities=self.entities, namespace="tenant1"
-            )
+            self.sensu.handle_proxy_entities(entities=self.entities, namespace="tenant1")
 
         mock_get_entities.assert_called_once_with(namespace="tenant1")
         self.assertEqual(mock_put.call_count, 2)
-        mock_put.assert_has_calls([
-            call(
-                "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant1/"
-                "entities/argo-devel.ni4os.eu",
-                data=json.dumps(self.entities[0]),
-                headers={
-                    "Authorization": "Key t0k3n",
-                    "Content-Type": "application/json"
-                }
-            ),
-            call(
-                "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant1/"
-                "entities/argo-mon.ni4os.eu",
-                data=json.dumps(self.entities[2]),
-                headers={
-                    "Authorization": "Key t0k3n",
-                    "Content-Type": "application/json"
-                }
-            )
-        ], any_order=True)
+        mock_put.assert_has_calls(
+            [
+                call(
+                    "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant1/"
+                    "entities/argo-devel.ni4os.eu",
+                    data=json.dumps(self.entities[0]),
+                    headers={"Authorization": "Key t0k3n", "Content-Type": "application/json"},
+                ),
+                call(
+                    "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant1/"
+                    "entities/argo-mon.ni4os.eu",
+                    data=json.dumps(self.entities[2]),
+                    headers={"Authorization": "Key t0k3n", "Content-Type": "application/json"},
+                ),
+            ],
+            any_order=True,
+        )
 
         mock_delete_entities.assert_called_once_with(
-            entities=["gocdb.ni4os.eu"],
-            namespace="tenant1"
+            entities=["gocdb.ni4os.eu"], namespace="tenant1"
         )
 
         self.assertEqual(
-            set(log.output), {
+            set(log.output),
+            {
                 f"INFO:{LOGNAME}:tenant1: Entity argo-devel.ni4os.eu updated",
                 f"WARNING:{LOGNAME}:tenant1: Proxy entity argo-mon.ni4os.eu "
-                f"not created: 400 BAD REQUEST"
-            }
+                f"not created: 400 BAD REQUEST",
+            },
         )
 
 
@@ -6616,11 +5388,7 @@ class SensuAgentsTests(unittest.TestCase):
         self.sensu = Sensu(
             url="https://sensu.mock.com:8080",
             token="t0k3n",
-            namespaces={
-                "default": ["default"],
-                "tenant1": ["TENANT1"],
-                "tenant2": ["TENANT2"]
-            }
+            namespaces={"default": ["default"], "tenant1": ["TENANT1"], "tenant2": ["TENANT2"]},
         )
 
     @patch("requests.get")
@@ -6630,16 +5398,10 @@ class SensuAgentsTests(unittest.TestCase):
             _log_dummy()
             agents = self.sensu._get_agents(namespace="tenant1")
         mock_get.assert_called_once_with(
-            "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant1/"
-            "entities",
-            headers={
-                "Authorization": "Key t0k3n",
-                "Content-Type": "application/json"
-            }
+            "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant1/entities",
+            headers={"Authorization": "Key t0k3n", "Content-Type": "application/json"},
         )
-        self.assertEqual(
-            agents, [mock_entities[3], mock_entities[4]]
-        )
+        self.assertEqual(agents, [mock_entities[3], mock_entities[4]])
         self.assertEqual(log.output, DUMMY_LOG)
 
     @patch("requests.get")
@@ -6650,24 +5412,20 @@ class SensuAgentsTests(unittest.TestCase):
                 self.sensu._get_agents(namespace="tenant1")
 
         mock_get.assert_called_once_with(
-            "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant1/"
-            "entities",
-            headers={
-                "Authorization": "Key t0k3n",
-                "Content-Type": "application/json"
-            }
+            "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant1/entities",
+            headers={"Authorization": "Key t0k3n", "Content-Type": "application/json"},
         )
 
         self.assertEqual(
             context.exception.__str__(),
-            "Sensu error: tenant1: Error fetching agents: 400 BAD REQUEST: "
-            "Something went wrong."
+            "Sensu error: tenant1: Error fetching agents: 400 BAD REQUEST: Something went wrong.",
         )
         self.assertEqual(
-            log.output, [
+            log.output,
+            [
                 f"ERROR:{LOGNAME}:tenant1: Error fetching agents: "
                 f"400 BAD REQUEST: Something went wrong."
-            ]
+            ],
         )
 
     @patch("requests.get")
@@ -6678,30 +5436,21 @@ class SensuAgentsTests(unittest.TestCase):
                 self.sensu._get_agents(namespace="tenant1")
 
         mock_get.assert_called_once_with(
-            "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant1/"
-            "entities",
-            headers={
-                "Authorization": "Key t0k3n",
-                "Content-Type": "application/json"
-            }
+            "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant1/entities",
+            headers={"Authorization": "Key t0k3n", "Content-Type": "application/json"},
         )
 
         self.assertEqual(
             context.exception.__str__(),
-            "Sensu error: tenant1: Error fetching agents: 400 BAD REQUEST"
+            "Sensu error: tenant1: Error fetching agents: 400 BAD REQUEST",
         )
         self.assertEqual(
-            log.output, [
-                f"ERROR:{LOGNAME}:tenant1: Error fetching agents: "
-                f"400 BAD REQUEST"
-            ]
+            log.output, [f"ERROR:{LOGNAME}:tenant1: Error fetching agents: 400 BAD REQUEST"]
         )
 
     @patch("requests.patch")
     @patch("argo_scg.sensu.Sensu._get_agents")
-    def test_handle_agents_with_metric_parameter_overrides(
-            self, mock_get, mock_patch
-    ):
+    def test_handle_agents_with_metric_parameter_overrides(self, mock_get, mock_patch):
         mock_get.return_value = [mock_entities[3], mock_entities[4]]
         mock_patch.side_effect = mock_post_response
 
@@ -6712,62 +5461,63 @@ class SensuAgentsTests(unittest.TestCase):
                         "metric": "generic.tcp.connect",
                         "hostname": "sensu-agent1",
                         "label": "generic_tcp_connect_p",
-                        "value": "80"
+                        "value": "80",
                     }
                 ],
-                namespace="tenant1"
+                namespace="tenant1",
             )
 
         self.assertEqual(mock_patch.call_count, 2)
-        mock_patch.assert_has_calls([
-            call(
-                "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant1/"
-                "entities/sensu-agent1",
-                data=json.dumps({
-                    "subscriptions": [
-                        "entity:sensu-agent1"
-                    ],
-                    "metadata": {
-                        "labels": {
-                            "hostname": "sensu-agent1",
-                            "services": "internals",
-                            "generic_tcp_connect_p": "80"
+        mock_patch.assert_has_calls(
+            [
+                call(
+                    "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant1/"
+                    "entities/sensu-agent1",
+                    data=json.dumps(
+                        {
+                            "subscriptions": ["entity:sensu-agent1"],
+                            "metadata": {
+                                "labels": {
+                                    "hostname": "sensu-agent1",
+                                    "services": "internals",
+                                    "generic_tcp_connect_p": "80",
+                                }
+                            },
                         }
-                    }
-                }),
-                headers={
-                    "Authorization": "Key t0k3n",
-                    "Content-Type": "application/merge-patch+json"
-                }
-            ),
-            call(
-                "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant1/"
-                "entities/sensu-agent2",
-                data=json.dumps({
-                    "subscriptions": [
-                        "entity:sensu-agent2"
-                    ],
-                    "metadata": {
-                        "labels": {
-                            "hostname": "sensu-agent2",
-                            "services": "internals"
+                    ),
+                    headers={
+                        "Authorization": "Key t0k3n",
+                        "Content-Type": "application/merge-patch+json",
+                    },
+                ),
+                call(
+                    "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant1/"
+                    "entities/sensu-agent2",
+                    data=json.dumps(
+                        {
+                            "subscriptions": ["entity:sensu-agent2"],
+                            "metadata": {
+                                "labels": {"hostname": "sensu-agent2", "services": "internals"}
+                            },
                         }
-                    }
-                }),
-                headers={
-                    "Authorization": "Key t0k3n",
-                    "Content-Type": "application/merge-patch+json"
-                }
-            )
-        ], any_order=True)
+                    ),
+                    headers={
+                        "Authorization": "Key t0k3n",
+                        "Content-Type": "application/merge-patch+json",
+                    },
+                ),
+            ],
+            any_order=True,
+        )
 
         self.assertEqual(
-            set(log.output), {
+            set(log.output),
+            {
                 f"INFO:{LOGNAME}:tenant1: sensu-agent1 subscriptions updated",
                 f"INFO:{LOGNAME}:tenant1: sensu-agent1 labels updated",
                 f"INFO:{LOGNAME}:tenant1: sensu-agent2 subscriptions updated",
-                f"INFO:{LOGNAME}:tenant1: sensu-agent2 labels updated"
-            }
+                f"INFO:{LOGNAME}:tenant1: sensu-agent2 labels updated",
+            },
         )
 
     @patch("requests.patch")
@@ -6778,72 +5528,74 @@ class SensuAgentsTests(unittest.TestCase):
 
         with self.assertLogs(LOGNAME) as log:
             self.sensu.handle_agents(
-                host_attributes_overrides=[{
-                    "hostname": "sensu-agent1",
-                    "attribute": "NAGIOS_FRESHNESS_USERNAME",
-                    "value": "$NI4OS_NAGIOS_FRESHNESS_USERNAME"
-                }, {
-                    "hostname": "sensu-agent1",
-                    "attribute": "NAGIOS_FRESHNESS_PASSWORD",
-                    "value": "NI4OS_NAGIOS_FRESHNESS_PASSWORD"
-                }],
-                namespace="tenant1"
+                host_attributes_overrides=[
+                    {
+                        "hostname": "sensu-agent1",
+                        "attribute": "NAGIOS_FRESHNESS_USERNAME",
+                        "value": "$NI4OS_NAGIOS_FRESHNESS_USERNAME",
+                    },
+                    {
+                        "hostname": "sensu-agent1",
+                        "attribute": "NAGIOS_FRESHNESS_PASSWORD",
+                        "value": "NI4OS_NAGIOS_FRESHNESS_PASSWORD",
+                    },
+                ],
+                namespace="tenant1",
             )
 
         self.assertEqual(mock_patch.call_count, 2)
 
-        mock_patch.assert_has_calls([
-            call(
-                "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant1/"
-                "entities/sensu-agent1",
-                data=json.dumps({
-                    "subscriptions": [
-                        "entity:sensu-agent1"
-                    ],
-                    "metadata": {
-                        "labels": {
-                            "hostname": "sensu-agent1",
-                            "services": "internals",
-                            "nagios_freshness_username":
-                                "$NI4OS_NAGIOS_FRESHNESS_USERNAME",
-                            "nagios_freshness_password":
-                                "$NI4OS_NAGIOS_FRESHNESS_PASSWORD",
+        mock_patch.assert_has_calls(
+            [
+                call(
+                    "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant1/"
+                    "entities/sensu-agent1",
+                    data=json.dumps(
+                        {
+                            "subscriptions": ["entity:sensu-agent1"],
+                            "metadata": {
+                                "labels": {
+                                    "hostname": "sensu-agent1",
+                                    "services": "internals",
+                                    "nagios_freshness_username": "$NI4OS_NAGIOS_FRESHNESS_USERNAME",
+                                    "nagios_freshness_password": "$NI4OS_NAGIOS_FRESHNESS_PASSWORD",
+                                }
+                            },
                         }
-                    }
-                }),
-                headers={
-                    "Authorization": "Key t0k3n",
-                    "Content-Type": "application/merge-patch+json"
-                }
-            ),
-            call(
-                "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant1/"
-                "entities/sensu-agent2",
-                data=json.dumps({
-                    "subscriptions": [
-                        "entity:sensu-agent2"
-                    ],
-                    "metadata": {
-                        "labels": {
-                            "hostname": "sensu-agent2",
-                            "services": "internals"
+                    ),
+                    headers={
+                        "Authorization": "Key t0k3n",
+                        "Content-Type": "application/merge-patch+json",
+                    },
+                ),
+                call(
+                    "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant1/"
+                    "entities/sensu-agent2",
+                    data=json.dumps(
+                        {
+                            "subscriptions": ["entity:sensu-agent2"],
+                            "metadata": {
+                                "labels": {"hostname": "sensu-agent2", "services": "internals"}
+                            },
                         }
-                    }
-                }),
-                headers={
-                    "Authorization": "Key t0k3n",
-                    "Content-Type": "application/merge-patch+json"
-                }
-            )
-        ], any_order=True)
+                    ),
+                    headers={
+                        "Authorization": "Key t0k3n",
+                        "Content-Type": "application/merge-patch+json",
+                    },
+                ),
+            ],
+            any_order=True,
+        )
 
         self.assertEqual(
-            set(log.output), {
+            set(log.output),
+            {
                 f"INFO:{LOGNAME}:tenant1: sensu-agent1 subscriptions updated",
                 f"INFO:{LOGNAME}:tenant1: sensu-agent1 labels updated",
                 f"INFO:{LOGNAME}:tenant1: sensu-agent2 subscriptions updated",
-                f"INFO:{LOGNAME}:tenant1: sensu-agent2 labels updated"
-            }
+                f"INFO:{LOGNAME}:tenant1: sensu-agent2 labels updated",
+            },
         )
 
     @patch("requests.patch")
@@ -6853,61 +5605,62 @@ class SensuAgentsTests(unittest.TestCase):
         mock_patch.side_effect = mock_post_response
 
         with self.assertLogs(LOGNAME) as log:
-            self.sensu.handle_agents(
-                services="argo.mon,argo.test",
-                namespace="tenant1"
-            )
+            self.sensu.handle_agents(services="argo.mon,argo.test", namespace="tenant1")
 
         self.assertEqual(mock_patch.call_count, 2)
 
-        mock_patch.assert_has_calls([
-            call(
-                "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant1/"
-                "entities/sensu-agent1",
-                data=json.dumps({
-                    "subscriptions": [
-                        "entity:sensu-agent1"
-                    ],
-                    "metadata": {
-                        "labels": {
-                            "hostname": "sensu-agent1",
-                            "services": "argo.mon,argo.test"
+        mock_patch.assert_has_calls(
+            [
+                call(
+                    "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant1/"
+                    "entities/sensu-agent1",
+                    data=json.dumps(
+                        {
+                            "subscriptions": ["entity:sensu-agent1"],
+                            "metadata": {
+                                "labels": {
+                                    "hostname": "sensu-agent1",
+                                    "services": "argo.mon,argo.test",
+                                }
+                            },
                         }
-                    }
-                }),
-                headers={
-                    "Authorization": "Key t0k3n",
-                    "Content-Type": "application/merge-patch+json"
-                }
-            ),
-            call(
-                "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant1/"
-                "entities/sensu-agent2",
-                data=json.dumps({
-                    "subscriptions": [
-                        "entity:sensu-agent2"
-                    ],
-                    "metadata": {
-                        "labels": {
-                            "hostname": "sensu-agent2",
-                            "services": "argo.mon,argo.test"
+                    ),
+                    headers={
+                        "Authorization": "Key t0k3n",
+                        "Content-Type": "application/merge-patch+json",
+                    },
+                ),
+                call(
+                    "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant1/"
+                    "entities/sensu-agent2",
+                    data=json.dumps(
+                        {
+                            "subscriptions": ["entity:sensu-agent2"],
+                            "metadata": {
+                                "labels": {
+                                    "hostname": "sensu-agent2",
+                                    "services": "argo.mon,argo.test",
+                                }
+                            },
                         }
-                    }
-                }),
-                headers={
-                    "Authorization": "Key t0k3n",
-                    "Content-Type": "application/merge-patch+json"
-                }
-            )
-        ], any_order=True)
+                    ),
+                    headers={
+                        "Authorization": "Key t0k3n",
+                        "Content-Type": "application/merge-patch+json",
+                    },
+                ),
+            ],
+            any_order=True,
+        )
 
         self.assertEqual(
-            set(log.output), {
+            set(log.output),
+            {
                 f"INFO:{LOGNAME}:tenant1: sensu-agent1 subscriptions updated",
                 f"INFO:{LOGNAME}:tenant1: sensu-agent1 labels updated",
                 f"INFO:{LOGNAME}:tenant1: sensu-agent2 subscriptions updated",
-                f"INFO:{LOGNAME}:tenant1: sensu-agent2 labels updated"
-            }
+                f"INFO:{LOGNAME}:tenant1: sensu-agent2 labels updated",
+            },
         )
 
 
@@ -6916,30 +5669,20 @@ class SensuHandlersTests(unittest.TestCase):
         self.sensu = Sensu(
             url="https://sensu.mock.com:8080",
             token="t0k3n",
-            namespaces={
-                "default": ["default"],
-                "tenant1": ["TENANT1"],
-                "tenant2": ["TENANT2"]
-            }
+            namespaces={"default": ["default"], "tenant1": ["TENANT1"], "tenant2": ["TENANT2"]},
         )
         self.publisher_handler = {
-            "metadata": {
-                "name": "publisher-handler",
-                "namespace": "tenant1"
-            },
+            "metadata": {"name": "publisher-handler", "namespace": "tenant1"},
             "type": "pipe",
-            "command": "/bin/sensu2publisher.py"
+            "command": "/bin/sensu2publisher.py",
         }
         self.slack_handler = {
-            "metadata": {
-                "name": "slack",
-                "namespace": "tenant1"
-            },
+            "metadata": {"name": "slack", "namespace": "tenant1"},
             "type": "pipe",
             "command": "source /etc/sensu/secrets ; "
-                       "export $(cut -d= -f1 /etc/sensu/secrets) ; "
-                       "sensu-slack-handler --channel '#monitoring'",
-            "runtime_assets": ["sensu-slack-handler"]
+            "export $(cut -d= -f1 /etc/sensu/secrets) ; "
+            "sensu-slack-handler --channel '#monitoring'",
+            "runtime_assets": ["sensu-slack-handler"],
         }
 
     @patch("requests.get")
@@ -6949,12 +5692,8 @@ class SensuHandlersTests(unittest.TestCase):
             _log_dummy()
             handlers = self.sensu._get_handlers(namespace="tenant1")
         mock_get.assert_called_once_with(
-            "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant1/"
-            "handlers",
-            headers={
-                "Authorization": "Key t0k3n",
-                "Content-Type": "application/json"
-            }
+            "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant1/handlers",
+            headers={"Authorization": "Key t0k3n", "Content-Type": "application/json"},
         )
         self.assertEqual(handlers, mock_handlers1)
         self.assertEqual(log.output, DUMMY_LOG)
@@ -6966,24 +5705,20 @@ class SensuHandlersTests(unittest.TestCase):
             with self.assertLogs(LOGNAME) as log:
                 self.sensu._get_handlers(namespace="tenant1")
         mock_get.assert_called_once_with(
-            "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant1/"
-            "handlers",
-            headers={
-                "Authorization": "Key t0k3n",
-                "Content-Type": "application/json"
-            }
+            "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant1/handlers",
+            headers={"Authorization": "Key t0k3n", "Content-Type": "application/json"},
         )
 
         self.assertEqual(
             context.exception.__str__(),
-            "Sensu error: tenant1: Handlers fetch error: 400 BAD REQUEST: "
-            "Something went wrong."
+            "Sensu error: tenant1: Handlers fetch error: 400 BAD REQUEST: Something went wrong.",
         )
         self.assertEqual(
-            log.output, [
+            log.output,
+            [
                 f"ERROR:{LOGNAME}:tenant1: Handlers fetch error: "
                 f"400 BAD REQUEST: Something went wrong."
-            ]
+            ],
         )
 
     @patch("requests.get")
@@ -6994,23 +5729,16 @@ class SensuHandlersTests(unittest.TestCase):
                 self.sensu._get_handlers(namespace="tenant1")
 
         mock_get.assert_called_once_with(
-            "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant1/"
-            "handlers",
-            headers={
-                "Authorization": "Key t0k3n",
-                "Content-Type": "application/json"
-            }
+            "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant1/handlers",
+            headers={"Authorization": "Key t0k3n", "Content-Type": "application/json"},
         )
 
         self.assertEqual(
             context.exception.__str__(),
-            "Sensu error: tenant1: Handlers fetch error: 400 BAD REQUEST"
+            "Sensu error: tenant1: Handlers fetch error: 400 BAD REQUEST",
         )
         self.assertEqual(
-            log.output, [
-                f"ERROR:{LOGNAME}:tenant1: Handlers fetch error: "
-                f"400 BAD REQUEST"
-            ]
+            log.output, [f"ERROR:{LOGNAME}:tenant1: Handlers fetch error: 400 BAD REQUEST"]
         )
 
     @patch("requests.post")
@@ -7022,24 +5750,16 @@ class SensuHandlersTests(unittest.TestCase):
             self.sensu.handle_publisher_handler(namespace="tenant1")
         mock_get_handlers.assert_called_once_with(namespace="tenant1")
         mock_post.assert_called_once_with(
-            "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant1/"
-            "handlers",
+            "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant1/handlers",
             data=json.dumps(self.publisher_handler),
-            headers={
-                "Authorization": "Key t0k3n",
-                "Content-Type": "application/json"
-            }
+            headers={"Authorization": "Key t0k3n", "Content-Type": "application/json"},
         )
 
-        self.assertEqual(
-            log.output, [f"INFO:{LOGNAME}:tenant1: publisher-handler created"]
-        )
+        self.assertEqual(log.output, [f"INFO:{LOGNAME}:tenant1: publisher-handler created"])
 
     @patch("requests.post")
     @patch("argo_scg.sensu.Sensu._get_handlers")
-    def test_handle_publisher_handler_with_error_with_msg(
-            self, mock_get_handlers, mock_post
-    ):
+    def test_handle_publisher_handler_with_error_with_msg(self, mock_get_handlers, mock_post):
         mock_get_handlers.return_value = mock_handlers1
         mock_post.side_effect = mock_post_response_not_ok_with_msg
         with self.assertRaises(SensuException) as context:
@@ -7048,31 +5768,26 @@ class SensuHandlersTests(unittest.TestCase):
 
         mock_get_handlers.assert_called_once_with(namespace="tenant1")
         mock_post.assert_called_once_with(
-            "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant1/"
-            "handlers",
+            "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant1/handlers",
             data=json.dumps(self.publisher_handler),
-            headers={
-                "Authorization": "Key t0k3n",
-                "Content-Type": "application/json"
-            }
+            headers={"Authorization": "Key t0k3n", "Content-Type": "application/json"},
         )
         self.assertEqual(
             context.exception.__str__(),
             "Sensu error: tenant1: publisher-handler create error: "
-            "400 BAD REQUEST: Something went wrong."
+            "400 BAD REQUEST: Something went wrong.",
         )
         self.assertEqual(
-            log.output, [
+            log.output,
+            [
                 f"ERROR:{LOGNAME}:tenant1: publisher-handler create error: "
                 f"400 BAD REQUEST: Something went wrong."
-            ]
+            ],
         )
 
     @patch("requests.post")
     @patch("argo_scg.sensu.Sensu._get_handlers")
-    def test_handle_publisher_handler_with_error_without_msg(
-            self, mock_get_handlers, mock_post
-    ):
+    def test_handle_publisher_handler_with_error_without_msg(self, mock_get_handlers, mock_post):
         mock_get_handlers.return_value = mock_handlers1
         mock_post.side_effect = mock_post_response_not_ok_without_msg
         with self.assertRaises(SensuException) as context:
@@ -7080,31 +5795,22 @@ class SensuHandlersTests(unittest.TestCase):
                 self.sensu.handle_publisher_handler(namespace="tenant1")
         mock_get_handlers.assert_called_once_with(namespace="tenant1")
         mock_post.assert_called_once_with(
-            "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant1/"
-            "handlers",
+            "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant1/handlers",
             data=json.dumps(self.publisher_handler),
-            headers={
-                "Authorization": "Key t0k3n",
-                "Content-Type": "application/json"
-            }
+            headers={"Authorization": "Key t0k3n", "Content-Type": "application/json"},
         )
         self.assertEqual(
             context.exception.__str__(),
-            "Sensu error: tenant1: publisher-handler create error: "
-            "400 BAD REQUEST"
+            "Sensu error: tenant1: publisher-handler create error: 400 BAD REQUEST",
         )
         self.assertEqual(
-            log.output, [
-                f"ERROR:{LOGNAME}:tenant1: publisher-handler create error: "
-                f"400 BAD REQUEST"
-            ]
+            log.output,
+            [f"ERROR:{LOGNAME}:tenant1: publisher-handler create error: 400 BAD REQUEST"],
         )
 
     @patch("requests.post")
     @patch("argo_scg.sensu.Sensu._get_handlers")
-    def test_handle_publisher_handler_if_exists_and_same(
-            self, mock_get_handlers, mock_post
-    ):
+    def test_handle_publisher_handler_if_exists_and_same(self, mock_get_handlers, mock_post):
         mock_get_handlers.return_value = mock_handlers2
         mock_post.side_effect = mock_post_response
         with self.assertLogs(LOGNAME) as log:
@@ -7116,35 +5822,23 @@ class SensuHandlersTests(unittest.TestCase):
 
     @patch("requests.patch")
     @patch("argo_scg.sensu.Sensu._get_handlers")
-    def test_handle_publisher_handler_if_exists_and_different(
-            self, mock_get_handlers, mock_patch
-    ):
+    def test_handle_publisher_handler_if_exists_and_different(self, mock_get_handlers, mock_patch):
         mock_get_handlers.return_value = mock_handlers3
         mock_patch.side_effect = mock_post_response
         with self.assertLogs(LOGNAME) as log:
             self.sensu.handle_publisher_handler(namespace="tenant1")
         mock_get_handlers.assert_called_once_with(namespace="tenant1")
         mock_patch.assert_called_once_with(
-            "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant1/"
-            "handlers/publisher-handler",
-            data=json.dumps({
-                "command": "/bin/sensu2publisher.py"
-            }),
-            headers={
-                "Authorization": "Key t0k3n",
-                "Content-Type": "application/merge-patch+json"
-            }
+            "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant1/handlers/publisher-handler",
+            data=json.dumps({"command": "/bin/sensu2publisher.py"}),
+            headers={"Authorization": "Key t0k3n", "Content-Type": "application/merge-patch+json"},
         )
-        self.assertEqual(
-            log.output, [
-                f"INFO:{LOGNAME}:tenant1: publisher-handler updated"
-            ]
-        )
+        self.assertEqual(log.output, [f"INFO:{LOGNAME}:tenant1: publisher-handler updated"])
 
     @patch("requests.patch")
     @patch("argo_scg.sensu.Sensu._get_handlers")
     def test_handle_publisher_handler_if_exists_and_different_with_err_with_msg(
-            self, mock_get_handlers, mock_patch
+        self, mock_get_handlers, mock_patch
     ):
         mock_get_handlers.return_value = mock_handlers3
         mock_patch.side_effect = mock_post_response_not_ok_with_msg
@@ -7152,27 +5846,22 @@ class SensuHandlersTests(unittest.TestCase):
             self.sensu.handle_publisher_handler(namespace="tenant1")
         mock_get_handlers.assert_called_once_with(namespace="tenant1")
         mock_patch.assert_called_once_with(
-            "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant1/"
-            "handlers/publisher-handler",
-            data=json.dumps({
-                "command": "/bin/sensu2publisher.py"
-            }),
-            headers={
-                "Authorization": "Key t0k3n",
-                "Content-Type": "application/merge-patch+json"
-            }
+            "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant1/handlers/publisher-handler",
+            data=json.dumps({"command": "/bin/sensu2publisher.py"}),
+            headers={"Authorization": "Key t0k3n", "Content-Type": "application/merge-patch+json"},
         )
         self.assertEqual(
-            log.output, [
+            log.output,
+            [
                 f"WARNING:{LOGNAME}:tenant1: publisher-handler not updated: "
                 f"400 BAD REQUEST: Something went wrong.",
-            ]
+            ],
         )
 
     @patch("requests.patch")
     @patch("argo_scg.sensu.Sensu._get_handlers")
     def test_handle_publisher_handler_if_exists_and_different_with_err_no_msg(
-            self, mock_get_handlers, mock_patch
+        self, mock_get_handlers, mock_patch
     ):
         mock_get_handlers.return_value = mock_handlers3
         mock_patch.side_effect = mock_post_response_not_ok_without_msg
@@ -7180,21 +5869,15 @@ class SensuHandlersTests(unittest.TestCase):
             self.sensu.handle_publisher_handler(namespace="tenant1")
         mock_get_handlers.assert_called_once_with(namespace="tenant1")
         mock_patch.assert_called_once_with(
-            "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant1/"
-            "handlers/publisher-handler",
-            data=json.dumps({
-                "command": "/bin/sensu2publisher.py"
-            }),
-            headers={
-                "Authorization": "Key t0k3n",
-                "Content-Type": "application/merge-patch+json"
-            }
+            "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant1/handlers/publisher-handler",
+            data=json.dumps({"command": "/bin/sensu2publisher.py"}),
+            headers={"Authorization": "Key t0k3n", "Content-Type": "application/merge-patch+json"},
         )
         self.assertEqual(
-            log.output, [
-                f"WARNING:{LOGNAME}:tenant1: publisher-handler not updated: "
-                f"400 BAD REQUEST",
-            ]
+            log.output,
+            [
+                f"WARNING:{LOGNAME}:tenant1: publisher-handler not updated: 400 BAD REQUEST",
+            ],
         )
 
     @patch("requests.post")
@@ -7203,28 +5886,18 @@ class SensuHandlersTests(unittest.TestCase):
         mock_get_handlers.return_value = mock_handlers1
         mock_post.side_effect = mock_post_response
         with self.assertLogs(LOGNAME) as log:
-            self.sensu.handle_slack_handler(
-                secrets_file="/etc/sensu/secrets", namespace="tenant1"
-            )
+            self.sensu.handle_slack_handler(secrets_file="/etc/sensu/secrets", namespace="tenant1")
         mock_get_handlers.assert_called_once_with(namespace="tenant1")
         mock_post.assert_called_once_with(
-            "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant1/"
-            "handlers",
+            "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant1/handlers",
             data=json.dumps(self.slack_handler),
-            headers={
-                "Authorization": "Key t0k3n",
-                "Content-Type": "application/json"
-            }
+            headers={"Authorization": "Key t0k3n", "Content-Type": "application/json"},
         )
-        self.assertEqual(
-            log.output, [f"INFO:{LOGNAME}:tenant1: slack-handler created"]
-        )
+        self.assertEqual(log.output, [f"INFO:{LOGNAME}:tenant1: slack-handler created"])
 
     @patch("requests.post")
     @patch("argo_scg.sensu.Sensu._get_handlers")
-    def test_handle_slack_handler_with_error_with_msg(
-            self, mock_get_handlers, mock_post
-    ):
+    def test_handle_slack_handler_with_error_with_msg(self, mock_get_handlers, mock_post):
         mock_get_handlers.return_value = mock_handlers1
         mock_post.side_effect = mock_post_response_not_ok_with_msg
         with self.assertRaises(SensuException) as context:
@@ -7234,31 +5907,26 @@ class SensuHandlersTests(unittest.TestCase):
                 )
         mock_get_handlers.assert_called_once_with(namespace="tenant1")
         mock_post.assert_called_once_with(
-            "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant1/"
-            "handlers",
+            "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant1/handlers",
             data=json.dumps(self.slack_handler),
-            headers={
-                "Authorization": "Key t0k3n",
-                "Content-Type": "application/json"
-            }
+            headers={"Authorization": "Key t0k3n", "Content-Type": "application/json"},
         )
         self.assertEqual(
             context.exception.__str__(),
             "Sensu error: tenant1: slack-handler create error: "
-            "400 BAD REQUEST: Something went wrong."
+            "400 BAD REQUEST: Something went wrong.",
         )
         self.assertEqual(
-            log.output, [
+            log.output,
+            [
                 f"ERROR:{LOGNAME}:tenant1: slack-handler create error: "
                 f"400 BAD REQUEST: Something went wrong."
-            ]
+            ],
         )
 
     @patch("requests.post")
     @patch("argo_scg.sensu.Sensu._get_handlers")
-    def test_handle_slack_handler_with_error_without_msg(
-            self, mock_get_handlers, mock_post
-    ):
+    def test_handle_slack_handler_with_error_without_msg(self, mock_get_handlers, mock_post):
         mock_get_handlers.return_value = mock_handlers1
         mock_post.side_effect = mock_post_response_not_ok_without_msg
         with self.assertRaises(SensuException) as context:
@@ -7268,133 +5936,103 @@ class SensuHandlersTests(unittest.TestCase):
                 )
         mock_get_handlers.assert_called_once_with(namespace="tenant1")
         mock_post.assert_called_once_with(
-            "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant1/"
-            "handlers",
+            "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant1/handlers",
             data=json.dumps(self.slack_handler),
-            headers={
-                "Authorization": "Key t0k3n",
-                "Content-Type": "application/json"
-            }
+            headers={"Authorization": "Key t0k3n", "Content-Type": "application/json"},
         )
         self.assertEqual(
             context.exception.__str__(),
-            "Sensu error: tenant1: slack-handler create error: "
-            "400 BAD REQUEST"
+            "Sensu error: tenant1: slack-handler create error: 400 BAD REQUEST",
         )
         self.assertEqual(
-            log.output, [
-                f"ERROR:{LOGNAME}:tenant1: slack-handler create error: "
-                f"400 BAD REQUEST"
-            ]
+            log.output, [f"ERROR:{LOGNAME}:tenant1: slack-handler create error: 400 BAD REQUEST"]
         )
 
     @patch("requests.post")
     @patch("argo_scg.sensu.Sensu._get_handlers")
-    def test_handle_slack_handler_if_exists_and_same(
-            self, mock_get_handlers, mock_post
-    ):
+    def test_handle_slack_handler_if_exists_and_same(self, mock_get_handlers, mock_post):
         mock_get_handlers.return_value = mock_handlers2
         mock_post.side_effect = mock_post_response
         with self.assertLogs(LOGNAME) as log:
             _log_dummy()
-            self.sensu.handle_slack_handler(
-                secrets_file="/etc/sensu/secrets", namespace="tenant1"
-            )
+            self.sensu.handle_slack_handler(secrets_file="/etc/sensu/secrets", namespace="tenant1")
         mock_get_handlers.assert_called_once_with(namespace="tenant1")
         self.assertFalse(mock_post.called)
         self.assertEqual(log.output, DUMMY_LOG)
 
     @patch("requests.patch")
     @patch("argo_scg.sensu.Sensu._get_handlers")
-    def test_handle_slack_handler_if_exists_and_different(
-            self, mock_get_handlers, mock_patch
-    ):
+    def test_handle_slack_handler_if_exists_and_different(self, mock_get_handlers, mock_patch):
         mock_get_handlers.return_value = mock_handlers3
         mock_patch.side_effect = mock_post_response
         with self.assertLogs(LOGNAME) as log:
-            self.sensu.handle_slack_handler(
-                secrets_file="/etc/sensu/secrets", namespace="tenant1"
-            )
+            self.sensu.handle_slack_handler(secrets_file="/etc/sensu/secrets", namespace="tenant1")
         mock_get_handlers.assert_called_once_with(namespace="tenant1")
         mock_patch.assert_called_once_with(
-            "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant1/"
-            "handlers/slack",
-            data=json.dumps({
-                "command": "source /etc/sensu/secrets ; "
-                           "export $(cut -d= -f1 /etc/sensu/secrets) ; "
-                           "sensu-slack-handler --channel '#monitoring'"
-            }),
-            headers={
-                "Authorization": "Key t0k3n",
-                "Content-Type": "application/merge-patch+json"
-            }
+            "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant1/handlers/slack",
+            data=json.dumps(
+                {
+                    "command": "source /etc/sensu/secrets ; "
+                    "export $(cut -d= -f1 /etc/sensu/secrets) ; "
+                    "sensu-slack-handler --channel '#monitoring'"
+                }
+            ),
+            headers={"Authorization": "Key t0k3n", "Content-Type": "application/merge-patch+json"},
         )
-        self.assertEqual(
-            log.output, [f"INFO:{LOGNAME}:tenant1: slack-handler updated"]
-        )
+        self.assertEqual(log.output, [f"INFO:{LOGNAME}:tenant1: slack-handler updated"])
 
     @patch("requests.patch")
     @patch("argo_scg.sensu.Sensu._get_handlers")
     def test_handle_slack_handler_if_exists_and_different_with_err_with_msg(
-            self, mock_get_handlers, mock_patch
+        self, mock_get_handlers, mock_patch
     ):
         mock_get_handlers.return_value = mock_handlers3
         mock_patch.side_effect = mock_post_response_not_ok_with_msg
         with self.assertLogs(LOGNAME) as log:
-            self.sensu.handle_slack_handler(
-                secrets_file="/etc/sensu/secrets", namespace="tenant1"
-            )
+            self.sensu.handle_slack_handler(secrets_file="/etc/sensu/secrets", namespace="tenant1")
         mock_get_handlers.assert_called_once_with(namespace="tenant1")
         mock_patch.assert_called_once_with(
-            "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant1/"
-            "handlers/slack",
-            data=json.dumps({
-                "command": "source /etc/sensu/secrets ; "
-                           "export $(cut -d= -f1 /etc/sensu/secrets) ; "
-                           "sensu-slack-handler --channel '#monitoring'"
-            }),
-            headers={
-                "Authorization": "Key t0k3n",
-                "Content-Type": "application/merge-patch+json"
-            }
+            "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant1/handlers/slack",
+            data=json.dumps(
+                {
+                    "command": "source /etc/sensu/secrets ; "
+                    "export $(cut -d= -f1 /etc/sensu/secrets) ; "
+                    "sensu-slack-handler --channel '#monitoring'"
+                }
+            ),
+            headers={"Authorization": "Key t0k3n", "Content-Type": "application/merge-patch+json"},
         )
         self.assertEqual(
-            log.output, [
+            log.output,
+            [
                 f"WARNING:{LOGNAME}:tenant1: slack-handler not updated: "
                 f"400 BAD REQUEST: Something went wrong."
-            ]
+            ],
         )
 
     @patch("requests.patch")
     @patch("argo_scg.sensu.Sensu._get_handlers")
     def test_handle_slack_handler_if_exists_and_different_with_err_without_msg(
-            self, mock_get_handlers, mock_patch
+        self, mock_get_handlers, mock_patch
     ):
         mock_get_handlers.return_value = mock_handlers3
         mock_patch.side_effect = mock_post_response_not_ok_without_msg
         with self.assertLogs(LOGNAME) as log:
-            self.sensu.handle_slack_handler(
-                secrets_file="/etc/sensu/secrets", namespace="tenant1"
-            )
+            self.sensu.handle_slack_handler(secrets_file="/etc/sensu/secrets", namespace="tenant1")
         mock_get_handlers.assert_called_once_with(namespace="tenant1")
         mock_patch.assert_called_once_with(
-            "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant1/"
-            "handlers/slack",
-            data=json.dumps({
-                "command": "source /etc/sensu/secrets ; "
-                           "export $(cut -d= -f1 /etc/sensu/secrets) ; "
-                           "sensu-slack-handler --channel '#monitoring'"
-            }),
-            headers={
-                "Authorization": "Key t0k3n",
-                "Content-Type": "application/merge-patch+json"
-            }
+            "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant1/handlers/slack",
+            data=json.dumps(
+                {
+                    "command": "source /etc/sensu/secrets ; "
+                    "export $(cut -d= -f1 /etc/sensu/secrets) ; "
+                    "sensu-slack-handler --channel '#monitoring'"
+                }
+            ),
+            headers={"Authorization": "Key t0k3n", "Content-Type": "application/merge-patch+json"},
         )
         self.assertEqual(
-            log.output, [
-                f"WARNING:{LOGNAME}:tenant1: slack-handler not updated: "
-                "400 BAD REQUEST"
-            ]
+            log.output, [f"WARNING:{LOGNAME}:tenant1: slack-handler not updated: 400 BAD REQUEST"]
         )
 
 
@@ -7403,17 +6041,10 @@ class SensuFiltersTests(unittest.TestCase):
         self.sensu = Sensu(
             url="https://sensu.mock.com:8080",
             token="t0k3n",
-            namespaces={
-                "default": ["default"],
-                "tenant1": ["TENANT1"],
-                "tenant2": ["TENANT2"]
-            }
+            namespaces={"default": ["default"], "tenant1": ["TENANT1"], "tenant2": ["TENANT2"]},
         )
         self.daily = {
-            "metadata": {
-                "name": "daily",
-                "namespace": "tenant1"
-            },
+            "metadata": {"name": "daily", "namespace": "tenant1"},
             "action": "allow",
             "expressions": [
                 "((event.check.occurrences == 1 && event.check.status == 0 && "
@@ -7424,19 +6055,16 @@ class SensuFiltersTests(unittest.TestCase):
                 "&& event.check.status != 0)) || "
                 "event.check.occurrences % "
                 "(86400 / event.check.interval) == 0"
-            ]
+            ],
         }
         self.hard = {
-            "metadata": {
-                "name": "hard-state",
-                "namespace": "tenant1"
-            },
+            "metadata": {"name": "hard-state", "namespace": "tenant1"},
             "action": "allow",
             "expressions": [
                 "((event.check.status == 0) || (event.check.occurrences >= "
                 "Number(event.check.annotations.attempts) "
                 "&& event.check.status != 0))"
-            ]
+            ],
         }
 
     @patch("requests.get")
@@ -7446,11 +6074,8 @@ class SensuFiltersTests(unittest.TestCase):
             _log_dummy()
             filters = self.sensu._get_filters(namespace="tenant1")
         mock_get.assert_called_once_with(
-            "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant1/"
-            "filters",
-            headers={
-                "Authorization": "Key t0k3n"
-            }
+            "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant1/filters",
+            headers={"Authorization": "Key t0k3n"},
         )
         self.assertEqual(filters, mock_filters1)
         self.assertEqual(log.output, DUMMY_LOG)
@@ -7463,23 +6088,20 @@ class SensuFiltersTests(unittest.TestCase):
                 self.sensu._get_filters(namespace="tenant1")
 
         mock_get.assert_called_once_with(
-            "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant1/"
-            "filters",
-            headers={
-                "Authorization": "Key t0k3n"
-            }
+            "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant1/filters",
+            headers={"Authorization": "Key t0k3n"},
         )
 
         self.assertEqual(
             context.exception.__str__(),
-            "Sensu error: tenant1: Filters fetch error: 400 BAD REQUEST: "
-            "Something went wrong."
+            "Sensu error: tenant1: Filters fetch error: 400 BAD REQUEST: Something went wrong.",
         )
         self.assertEqual(
-            log.output, [
+            log.output,
+            [
                 f"ERROR:{LOGNAME}:tenant1: Filters fetch error: "
                 f"400 BAD REQUEST: Something went wrong."
-            ]
+            ],
         )
 
     @patch("requests.get")
@@ -7490,21 +6112,15 @@ class SensuFiltersTests(unittest.TestCase):
                 self.sensu._get_filters(namespace="tenant1")
 
         mock_get.assert_called_once_with(
-            "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant1/"
-            "filters",
-            headers={
-                "Authorization": "Key t0k3n"
-            }
+            "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant1/filters",
+            headers={"Authorization": "Key t0k3n"},
         )
         self.assertEqual(
             context.exception.__str__(),
-            "Sensu error: tenant1: Filters fetch error: 400 BAD REQUEST"
+            "Sensu error: tenant1: Filters fetch error: 400 BAD REQUEST",
         )
         self.assertEqual(
-            log.output, [
-                f"ERROR:{LOGNAME}:tenant1: Filters fetch error: "
-                f"400 BAD REQUEST"
-            ]
+            log.output, [f"ERROR:{LOGNAME}:tenant1: Filters fetch error: 400 BAD REQUEST"]
         )
 
     @patch("requests.post")
@@ -7517,17 +6133,11 @@ class SensuFiltersTests(unittest.TestCase):
 
         mock_filters.assert_called_once_with(namespace="tenant1")
         mock_post.assert_called_once_with(
-            "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant1/"
-            "filters",
+            "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant1/filters",
             data=json.dumps(self.daily),
-            headers={
-                "Authorization": "Key t0k3n",
-                "Content-Type": "application/json"
-            }
+            headers={"Authorization": "Key t0k3n", "Content-Type": "application/json"},
         )
-        self.assertEqual(
-            log.output, [f"INFO:{LOGNAME}:tenant1: daily filter created"]
-        )
+        self.assertEqual(log.output, [f"INFO:{LOGNAME}:tenant1: daily filter created"])
 
     @patch("requests.post")
     @patch("argo_scg.sensu.Sensu._get_filters")
@@ -7540,26 +6150,23 @@ class SensuFiltersTests(unittest.TestCase):
 
         mock_filters.assert_called_once_with(namespace="tenant1")
         mock_post.assert_called_once_with(
-            "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant1/"
-            "filters",
+            "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant1/filters",
             data=json.dumps(self.daily),
-            headers={
-                "Authorization": "Key t0k3n",
-                "Content-Type": "application/json"
-            }
+            headers={"Authorization": "Key t0k3n", "Content-Type": "application/json"},
         )
 
         self.assertEqual(
             context.exception.__str__(),
             "Sensu error: tenant1: daily filter create error: "
-            "400 BAD REQUEST: Something went wrong."
+            "400 BAD REQUEST: Something went wrong.",
         )
 
         self.assertEqual(
-            log.output, [
+            log.output,
+            [
                 f"ERROR:{LOGNAME}:tenant1: daily filter create error: "
                 f"400 BAD REQUEST: Something went wrong."
-            ]
+            ],
         )
 
     @patch("requests.post")
@@ -7573,24 +6180,17 @@ class SensuFiltersTests(unittest.TestCase):
 
         mock_filters.assert_called_once_with(namespace="tenant1")
         mock_post.assert_called_once_with(
-            "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant1/"
-            "filters",
+            "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant1/filters",
             data=json.dumps(self.daily),
-            headers={
-                "Authorization": "Key t0k3n",
-                "Content-Type": "application/json"
-            }
+            headers={"Authorization": "Key t0k3n", "Content-Type": "application/json"},
         )
 
         self.assertEqual(
             context.exception.__str__(),
-            "Sensu error: tenant1: daily filter create error: 400 BAD REQUEST"
+            "Sensu error: tenant1: daily filter create error: 400 BAD REQUEST",
         )
         self.assertEqual(
-            log.output, [
-                f"ERROR:{LOGNAME}:tenant1: daily filter create error: "
-                f"400 BAD REQUEST"
-            ]
+            log.output, [f"ERROR:{LOGNAME}:tenant1: daily filter create error: 400 BAD REQUEST"]
         )
 
     @patch("requests.post")
@@ -7607,38 +6207,32 @@ class SensuFiltersTests(unittest.TestCase):
     @patch("requests.patch")
     @patch("requests.post")
     @patch("argo_scg.sensu.Sensu._get_filters")
-    def test_add_daily_filter_if_exists_and_different(
-            self, mock_filters, mock_post, mock_patch
-    ):
+    def test_add_daily_filter_if_exists_and_different(self, mock_filters, mock_post, mock_patch):
         mock_filters.return_value = mock_filters2
         with self.assertLogs(LOGNAME) as log:
             self.sensu.add_daily_filter(namespace="tenant1")
         mock_filters.assert_called_once_with(namespace="tenant1")
         self.assertFalse(mock_post.called)
         mock_patch.assert_called_once_with(
-            "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant1/"
-            "filters/daily",
-            data=json.dumps({
-                "expressions": [
-                    "((event.check.occurrences == 1 && event.check.status == 0 "
-                    "&& event.check.occurrences_watermark >= "
-                    "Number(event.check.annotations.attempts)) || "
-                    "(event.check.occurrences == "
-                    "Number(event.check.annotations.attempts) "
-                    "&& event.check.status != 0)) || "
-                    "event.check.occurrences % "
-                    "(86400 / event.check.interval) == 0"
-                ]
-            }),
-            headers={
-                "Authorization": "Key t0k3n",
-                "Content-Type": "application/merge-patch+json"
-            }
+            "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant1/filters/daily",
+            data=json.dumps(
+                {
+                    "expressions": [
+                        "((event.check.occurrences == 1 && event.check.status == 0 "
+                        "&& event.check.occurrences_watermark >= "
+                        "Number(event.check.annotations.attempts)) || "
+                        "(event.check.occurrences == "
+                        "Number(event.check.annotations.attempts) "
+                        "&& event.check.status != 0)) || "
+                        "event.check.occurrences % "
+                        "(86400 / event.check.interval) == 0"
+                    ]
+                }
+            ),
+            headers={"Authorization": "Key t0k3n", "Content-Type": "application/merge-patch+json"},
         )
 
-        self.assertEqual(
-            log.output, [f"INFO:{LOGNAME}:tenant1: daily filter updated"]
-        )
+        self.assertEqual(log.output, [f"INFO:{LOGNAME}:tenant1: daily filter updated"])
 
     @patch("requests.post")
     @patch("argo_scg.sensu.Sensu._get_filters")
@@ -7650,23 +6244,15 @@ class SensuFiltersTests(unittest.TestCase):
 
         mock_filters.assert_called_once_with(namespace="tenant1")
         mock_post.assert_called_once_with(
-            "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant1/"
-            "filters",
+            "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant1/filters",
             data=json.dumps(self.hard),
-            headers={
-                "Authorization": "Key t0k3n",
-                "Content-Type": "application/json"
-            }
+            headers={"Authorization": "Key t0k3n", "Content-Type": "application/json"},
         )
-        self.assertEqual(
-            log.output, [f"INFO:{LOGNAME}:tenant1: hard-state filter created"]
-        )
+        self.assertEqual(log.output, [f"INFO:{LOGNAME}:tenant1: hard-state filter created"])
 
     @patch("requests.post")
     @patch("argo_scg.sensu.Sensu._get_filters")
-    def test_add_hard_state_filter_with_err_with_msg(
-            self, mock_filters, mock_post
-    ):
+    def test_add_hard_state_filter_with_err_with_msg(self, mock_filters, mock_post):
         mock_filters.return_value = []
         mock_post.side_effect = mock_post_response_not_ok_with_msg
         with self.assertRaises(SensuException) as context:
@@ -7675,33 +6261,28 @@ class SensuFiltersTests(unittest.TestCase):
 
         mock_filters.assert_called_once_with(namespace="tenant1")
         mock_post.assert_called_once_with(
-            "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant1/"
-            "filters",
+            "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant1/filters",
             data=json.dumps(self.hard),
-            headers={
-                "Authorization": "Key t0k3n",
-                "Content-Type": "application/json"
-            }
+            headers={"Authorization": "Key t0k3n", "Content-Type": "application/json"},
         )
 
         self.assertEqual(
             context.exception.__str__(),
             "Sensu error: tenant1: hard-state filter create error: "
-            "400 BAD REQUEST: Something went wrong."
+            "400 BAD REQUEST: Something went wrong.",
         )
 
         self.assertEqual(
-            log.output, [
+            log.output,
+            [
                 f"ERROR:{LOGNAME}:tenant1: hard-state filter create error: "
                 f"400 BAD REQUEST: Something went wrong."
-            ]
+            ],
         )
 
     @patch("requests.post")
     @patch("argo_scg.sensu.Sensu._get_filters")
-    def test_add_hard_state_filter_with_err_no_msg(
-            self, mock_filters, mock_post
-    ):
+    def test_add_hard_state_filter_with_err_no_msg(self, mock_filters, mock_post):
         mock_filters.return_value = []
         mock_post.side_effect = mock_post_response_not_ok_without_msg
         with self.assertRaises(SensuException) as context:
@@ -7710,32 +6291,23 @@ class SensuFiltersTests(unittest.TestCase):
 
         mock_filters.assert_called_once_with(namespace="tenant1")
         mock_post.assert_called_once_with(
-            "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant1/"
-            "filters",
+            "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant1/filters",
             data=json.dumps(self.hard),
-            headers={
-                "Authorization": "Key t0k3n",
-                "Content-Type": "application/json"
-            }
+            headers={"Authorization": "Key t0k3n", "Content-Type": "application/json"},
         )
 
         self.assertEqual(
             context.exception.__str__(),
-            "Sensu error: tenant1: hard-state filter create error: "
-            "400 BAD REQUEST"
+            "Sensu error: tenant1: hard-state filter create error: 400 BAD REQUEST",
         )
         self.assertEqual(
-            log.output, [
-                f"ERROR:{LOGNAME}:tenant1: hard-state filter create error: "
-                f"400 BAD REQUEST"
-            ]
+            log.output,
+            [f"ERROR:{LOGNAME}:tenant1: hard-state filter create error: 400 BAD REQUEST"],
         )
 
     @patch("requests.post")
     @patch("argo_scg.sensu.Sensu._get_filters")
-    def test_add_hard_state_filter_if_exists_and_same(
-            self, mock_filters, mock_post
-    ):
+    def test_add_hard_state_filter_if_exists_and_same(self, mock_filters, mock_post):
         mock_filters.return_value = mock_filters1
         with self.assertLogs(LOGNAME) as log:
             _log_dummy()
@@ -7748,7 +6320,7 @@ class SensuFiltersTests(unittest.TestCase):
     @patch("requests.post")
     @patch("argo_scg.sensu.Sensu._get_filters")
     def test_add_hard_state_filter_if_exists_and_different(
-            self, mock_filters, mock_post, mock_patch
+        self, mock_filters, mock_post, mock_patch
     ):
         mock_filters.return_value = mock_filters2
         with self.assertLogs(LOGNAME) as log:
@@ -7756,24 +6328,20 @@ class SensuFiltersTests(unittest.TestCase):
         mock_filters.assert_called_once_with(namespace="tenant1")
         self.assertFalse(mock_post.called)
         mock_patch.assert_called_once_with(
-            "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant1/"
-            "filters/hard-state",
-            data=json.dumps({
-                "expressions": [
-                    "((event.check.status == 0) || (event.check.occurrences >= "
-                    "Number(event.check.annotations.attempts) "
-                    "&& event.check.status != 0))"
-                ]
-            }),
-            headers={
-                "Authorization": "Key t0k3n",
-                "Content-Type": "application/merge-patch+json"
-            }
+            "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant1/filters/hard-state",
+            data=json.dumps(
+                {
+                    "expressions": [
+                        "((event.check.status == 0) || (event.check.occurrences >= "
+                        "Number(event.check.annotations.attempts) "
+                        "&& event.check.status != 0))"
+                    ]
+                }
+            ),
+            headers={"Authorization": "Key t0k3n", "Content-Type": "application/merge-patch+json"},
         )
 
-        self.assertEqual(
-            log.output, [f"INFO:{LOGNAME}:tenant1: hard-state filter updated"]
-        )
+        self.assertEqual(log.output, [f"INFO:{LOGNAME}:tenant1: hard-state filter updated"])
 
 
 class SensuPipelinesTests(unittest.TestCase):
@@ -7781,68 +6349,38 @@ class SensuPipelinesTests(unittest.TestCase):
         self.sensu = Sensu(
             url="https://sensu.mock.com:8080",
             token="t0k3n",
-            namespaces={
-                "default": ["default"],
-                "tenant1": ["TENANT1"],
-                "tenant2": ["TENANT2"]
-            }
+            namespaces={"default": ["default"], "tenant1": ["TENANT1"], "tenant2": ["TENANT2"]},
         )
         self.reduce_alerts = {
-            "metadata": {
-                "name": "reduce_alerts",
-                "namespace": "tenant1"
-            },
+            "metadata": {"name": "reduce_alerts", "namespace": "tenant1"},
             "workflows": [
                 {
                     "name": "slack_alerts",
                     "filters": [
-                        {
-                            "name": "is_incident",
-                            "type": "EventFilter",
-                            "api_version": "core/v2"
-                        },
-                        {
-                            "name": "not_silenced",
-                            "type": "EventFilter",
-                            "api_version": "core/v2"
-                        },
-                        {
-                            "name": "daily",
-                            "type": "EventFilter",
-                            "api_version": "core/v2"
-                        }
+                        {"name": "is_incident", "type": "EventFilter", "api_version": "core/v2"},
+                        {"name": "not_silenced", "type": "EventFilter", "api_version": "core/v2"},
+                        {"name": "daily", "type": "EventFilter", "api_version": "core/v2"},
                     ],
-                    "handler": {
-                        "name": "slack",
-                        "type": "Handler",
-                        "api_version": "core/v2"
-                    }
+                    "handler": {"name": "slack", "type": "Handler", "api_version": "core/v2"},
                 }
-            ]
+            ],
         }
 
         self.hard_state = {
-            "metadata": {
-                "name": "hard_state",
-                "namespace": "tenant1"
-            },
+            "metadata": {"name": "hard_state", "namespace": "tenant1"},
             "workflows": [
                 {
                     "name": "mimic_hard_state",
                     "filters": [
-                        {
-                            "name": "hard-state",
-                            "type": "EventFilter",
-                            "api_version": "core/v2"
-                        }
+                        {"name": "hard-state", "type": "EventFilter", "api_version": "core/v2"}
                     ],
                     "handler": {
                         "name": "publisher-handler",
                         "type": "Handler",
-                        "api_version": "core/v2"
-                    }
+                        "api_version": "core/v2",
+                    },
                 }
-            ]
+            ],
         }
 
     @patch("requests.get")
@@ -7852,11 +6390,8 @@ class SensuPipelinesTests(unittest.TestCase):
             _log_dummy()
             pipelines = self.sensu._get_pipelines(namespace="tenant1")
         mock_get.assert_called_once_with(
-            "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant1/"
-            "pipelines",
-            headers={
-                "Authorization": "Key t0k3n"
-            }
+            "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant1/pipelines",
+            headers={"Authorization": "Key t0k3n"},
         )
         self.assertEqual(pipelines, mock_pipelines1)
         self.assertEqual(log.output, DUMMY_LOG)
@@ -7868,22 +6403,19 @@ class SensuPipelinesTests(unittest.TestCase):
             with self.assertLogs(LOGNAME) as log:
                 self.sensu._get_pipelines(namespace="tenant1")
         mock_get.assert_called_once_with(
-            "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant1/"
-            "pipelines",
-            headers={
-                "Authorization": "Key t0k3n"
-            }
+            "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant1/pipelines",
+            headers={"Authorization": "Key t0k3n"},
         )
         self.assertEqual(
             context.exception.__str__(),
-            "Sensu error: tenant1: Pipelines fetch error: 400 BAD REQUEST: "
-            "Something went wrong."
+            "Sensu error: tenant1: Pipelines fetch error: 400 BAD REQUEST: Something went wrong.",
         )
         self.assertEqual(
-            log.output, [
+            log.output,
+            [
                 f"ERROR:{LOGNAME}:tenant1: Pipelines fetch error: "
                 f"400 BAD REQUEST: Something went wrong."
-            ]
+            ],
         )
 
     @patch("requests.get")
@@ -7893,21 +6425,15 @@ class SensuPipelinesTests(unittest.TestCase):
             with self.assertLogs(LOGNAME) as log:
                 self.sensu._get_pipelines(namespace="tenant1")
         mock_get.assert_called_once_with(
-            "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant1/"
-            "pipelines",
-            headers={
-                "Authorization": "Key t0k3n"
-            }
+            "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant1/pipelines",
+            headers={"Authorization": "Key t0k3n"},
         )
         self.assertEqual(
             context.exception.__str__(),
-            "Sensu error: tenant1: Pipelines fetch error: 400 BAD REQUEST"
+            "Sensu error: tenant1: Pipelines fetch error: 400 BAD REQUEST",
         )
         self.assertEqual(
-            log.output, [
-                f"ERROR:{LOGNAME}:tenant1: Pipelines fetch error: "
-                f"400 BAD REQUEST"
-            ]
+            log.output, [f"ERROR:{LOGNAME}:tenant1: Pipelines fetch error: 400 BAD REQUEST"]
         )
 
     @patch("requests.post")
@@ -7919,18 +6445,11 @@ class SensuPipelinesTests(unittest.TestCase):
             self.sensu.add_reduce_alerts_pipeline(namespace="tenant1")
         mock_pipelines.assert_called_once_with(namespace="tenant1")
         mock_post.assert_called_once_with(
-            "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant1/"
-            "pipelines",
+            "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant1/pipelines",
             data=json.dumps(self.reduce_alerts),
-            headers={
-                "Authorization": "Key t0k3n",
-                "Content-Type": "application/json"
-            }
+            headers={"Authorization": "Key t0k3n", "Content-Type": "application/json"},
         )
-        self.assertEqual(
-            log.output,
-            [f"INFO:{LOGNAME}:tenant1: reduce_alerts pipeline created"]
-        )
+        self.assertEqual(log.output, [f"INFO:{LOGNAME}:tenant1: reduce_alerts pipeline created"])
 
     @patch("requests.post")
     @patch("argo_scg.sensu.Sensu._get_pipelines")
@@ -7942,25 +6461,22 @@ class SensuPipelinesTests(unittest.TestCase):
                 self.sensu.add_reduce_alerts_pipeline(namespace="tenant1")
         mock_pipelines.assert_called_once_with(namespace="tenant1")
         mock_post.assert_called_once_with(
-            "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant1/"
-            "pipelines",
+            "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant1/pipelines",
             data=json.dumps(self.reduce_alerts),
-            headers={
-                "Authorization": "Key t0k3n",
-                "Content-Type": "application/json"
-            }
+            headers={"Authorization": "Key t0k3n", "Content-Type": "application/json"},
         )
         self.assertEqual(
             context.exception.__str__(),
             "Sensu error: tenant1: reduce_alerts pipeline create error: "
-            "400 BAD REQUEST: Something went wrong."
+            "400 BAD REQUEST: Something went wrong.",
         )
         self.assertEqual(
-            log.output, [
+            log.output,
+            [
                 f"ERROR:{LOGNAME}:tenant1: "
                 f"reduce_alerts pipeline create error: "
                 f"400 BAD REQUEST: Something went wrong."
-            ]
+            ],
         )
 
     @patch("requests.post")
@@ -7973,25 +6489,17 @@ class SensuPipelinesTests(unittest.TestCase):
                 self.sensu.add_reduce_alerts_pipeline(namespace="tenant1")
         mock_pipelines.assert_called_once_with(namespace="tenant1")
         mock_post.assert_called_once_with(
-            "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant1/"
-            "pipelines",
+            "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant1/pipelines",
             data=json.dumps(self.reduce_alerts),
-            headers={
-                "Authorization": "Key t0k3n",
-                "Content-Type": "application/json"
-            }
+            headers={"Authorization": "Key t0k3n", "Content-Type": "application/json"},
         )
         self.assertEqual(
             context.exception.__str__(),
-            "Sensu error: tenant1: reduce_alerts pipeline create error: "
-            "400 BAD REQUEST"
+            "Sensu error: tenant1: reduce_alerts pipeline create error: 400 BAD REQUEST",
         )
         self.assertEqual(
-            log.output, [
-                f"ERROR:{LOGNAME}:tenant1: "
-                f"reduce_alerts pipeline create error: "
-                f"400 BAD REQUEST"
-            ]
+            log.output,
+            [f"ERROR:{LOGNAME}:tenant1: reduce_alerts pipeline create error: 400 BAD REQUEST"],
         )
 
     @patch("requests.post")
@@ -8008,53 +6516,44 @@ class SensuPipelinesTests(unittest.TestCase):
     @patch("requests.patch")
     @patch("requests.post")
     @patch("argo_scg.sensu.Sensu._get_pipelines")
-    def test_add_alert_pipe_if_exists_and_different(
-            self, mock_pipeline, mock_post, mock_patch
-    ):
+    def test_add_alert_pipe_if_exists_and_different(self, mock_pipeline, mock_post, mock_patch):
         mock_pipeline.return_value = mock_pipelines2
         with self.assertLogs(LOGNAME) as log:
             self.sensu.add_reduce_alerts_pipeline(namespace="tenant1")
         mock_pipeline.assert_called_once_with(namespace="tenant1")
         self.assertFalse(mock_post.called)
         mock_patch.assert_called_once_with(
-            "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant1/"
-            "pipelines/reduce_alerts",
-            data=json.dumps({
-                "workflows": [{
-                    "name": "slack_alerts",
-                    "filters": [
+            "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant1/pipelines/reduce_alerts",
+            data=json.dumps(
+                {
+                    "workflows": [
                         {
-                            "name": "is_incident",
-                            "type": "EventFilter",
-                            "api_version": "core/v2"
-                        },
-                        {
-                            "name": "not_silenced",
-                            "type": "EventFilter",
-                            "api_version": "core/v2"
-                        },
-                        {
-                            "name": "daily",
-                            "type": "EventFilter",
-                            "api_version": "core/v2"
+                            "name": "slack_alerts",
+                            "filters": [
+                                {
+                                    "name": "is_incident",
+                                    "type": "EventFilter",
+                                    "api_version": "core/v2",
+                                },
+                                {
+                                    "name": "not_silenced",
+                                    "type": "EventFilter",
+                                    "api_version": "core/v2",
+                                },
+                                {"name": "daily", "type": "EventFilter", "api_version": "core/v2"},
+                            ],
+                            "handler": {
+                                "name": "slack",
+                                "type": "Handler",
+                                "api_version": "core/v2",
+                            },
                         }
-                    ],
-                    "handler": {
-                        "name": "slack",
-                        "type": "Handler",
-                        "api_version": "core/v2"
-                    }
-                }]
-            }),
-            headers={
-                "Authorization": "Key t0k3n",
-                "Content-Type": "application/merge-patch+json"
-            }
+                    ]
+                }
+            ),
+            headers={"Authorization": "Key t0k3n", "Content-Type": "application/merge-patch+json"},
         )
-        self.assertEqual(
-            log.output,
-            [f"INFO:{LOGNAME}:tenant1: reduce_alerts pipeline updated"]
-        )
+        self.assertEqual(log.output, [f"INFO:{LOGNAME}:tenant1: reduce_alerts pipeline updated"])
 
     @patch("requests.post")
     @patch("argo_scg.sensu.Sensu._get_pipelines")
@@ -8065,18 +6564,11 @@ class SensuPipelinesTests(unittest.TestCase):
             self.sensu.add_hard_state_pipeline(namespace="tenant1")
         mock_pipelines.assert_called_once_with(namespace="tenant1")
         mock_post.assert_called_once_with(
-            "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant1/"
-            "pipelines",
+            "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant1/pipelines",
             data=json.dumps(self.hard_state),
-            headers={
-                "Authorization": "Key t0k3n",
-                "Content-Type": "application/json"
-            }
+            headers={"Authorization": "Key t0k3n", "Content-Type": "application/json"},
         )
-        self.assertEqual(
-            log.output,
-            [f"INFO:{LOGNAME}:tenant1: hard_state pipeline created"]
-        )
+        self.assertEqual(log.output, [f"INFO:{LOGNAME}:tenant1: hard_state pipeline created"])
 
     @patch("requests.post")
     @patch("argo_scg.sensu.Sensu._get_pipelines")
@@ -8088,25 +6580,22 @@ class SensuPipelinesTests(unittest.TestCase):
                 self.sensu.add_hard_state_pipeline(namespace="tenant1")
         mock_pipelines.assert_called_once_with(namespace="tenant1")
         mock_post.assert_called_once_with(
-            "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant1/"
-            "pipelines",
+            "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant1/pipelines",
             data=json.dumps(self.hard_state),
-            headers={
-                "Authorization": "Key t0k3n",
-                "Content-Type": "application/json"
-            }
+            headers={"Authorization": "Key t0k3n", "Content-Type": "application/json"},
         )
         self.assertEqual(
             context.exception.__str__(),
             "Sensu error: tenant1: hard_state pipeline create error: "
-            "400 BAD REQUEST: Something went wrong."
+            "400 BAD REQUEST: Something went wrong.",
         )
         self.assertEqual(
-            log.output, [
+            log.output,
+            [
                 f"ERROR:{LOGNAME}:tenant1: "
                 f"hard_state pipeline create error: "
                 f"400 BAD REQUEST: Something went wrong."
-            ]
+            ],
         )
 
     @patch("requests.post")
@@ -8119,25 +6608,17 @@ class SensuPipelinesTests(unittest.TestCase):
                 self.sensu.add_hard_state_pipeline(namespace="tenant1")
         mock_pipelines.assert_called_once_with(namespace="tenant1")
         mock_post.assert_called_once_with(
-            "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant1/"
-            "pipelines",
+            "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant1/pipelines",
             data=json.dumps(self.hard_state),
-            headers={
-                "Authorization": "Key t0k3n",
-                "Content-Type": "application/json"
-            }
+            headers={"Authorization": "Key t0k3n", "Content-Type": "application/json"},
         )
         self.assertEqual(
             context.exception.__str__(),
-            "Sensu error: tenant1: hard_state pipeline create error: "
-            "400 BAD REQUEST"
+            "Sensu error: tenant1: hard_state pipeline create error: 400 BAD REQUEST",
         )
         self.assertEqual(
-            log.output, [
-                f"ERROR:{LOGNAME}:tenant1: "
-                f"hard_state pipeline create error: "
-                f"400 BAD REQUEST"
-            ]
+            log.output,
+            [f"ERROR:{LOGNAME}:tenant1: hard_state pipeline create error: 400 BAD REQUEST"],
         )
 
     @patch("requests.post")
@@ -8157,66 +6638,37 @@ class SensuUsageChecksTests(unittest.TestCase):
         self.sensu = Sensu(
             url="https://sensu.mock.com:8080",
             token="t0k3n",
-            namespaces={
-                "default": ["default"],
-                "tenant1": ["TENANT1"],
-                "tenant2": ["TENANT2"]
-            }
+            namespaces={"default": ["default"], "tenant1": ["TENANT1"], "tenant2": ["TENANT2"]},
         )
         self.cpu_check = {
             "command": "check-cpu-usage -w 85 -c 90",
             "interval": 300,
             "publish": True,
-            "runtime_assets": [
-                "check-cpu-usage"
-            ],
-            "subscriptions": [
-                "entity:sensu-agent1",
-                "entity:sensu-agent2"
-            ],
+            "runtime_assets": ["check-cpu-usage"],
+            "subscriptions": ["entity:sensu-agent1", "entity:sensu-agent2"],
             "timeout": 900,
             "round_robin": False,
             "metadata": {
                 "name": "sensu.cpu.usage",
                 "namespace": "tenant1",
-                "annotations": {
-                    "attempts": "3"
-                }
+                "annotations": {"attempts": "3"},
             },
-            "pipelines": [
-                {
-                    "name": "reduce_alerts",
-                    "type": "Pipeline",
-                    "api_version": "core/v2"
-                }
-            ]
+            "pipelines": [{"name": "reduce_alerts", "type": "Pipeline", "api_version": "core/v2"}],
         }
         self.memory_check = {
             "command": "check-memory-usage -w 85 -c 90",
             "interval": 300,
             "publish": True,
-            "runtime_assets": [
-                "check-memory-usage"
-            ],
-            "subscriptions": [
-                "entity:sensu-agent1"
-            ],
+            "runtime_assets": ["check-memory-usage"],
+            "subscriptions": ["entity:sensu-agent1"],
             "timeout": 900,
             "round_robin": False,
             "metadata": {
                 "name": "sensu.memory.usage",
                 "namespace": "tenant1",
-                "annotations": {
-                    "attempts": "3"
-                }
+                "annotations": {"attempts": "3"},
             },
-            "pipelines": [
-                {
-                    "name": "reduce_alerts",
-                    "type": "Pipeline",
-                    "api_version": "core/v2"
-                }
-            ]
+            "pipelines": [{"name": "reduce_alerts", "type": "Pipeline", "api_version": "core/v2"}],
         }
 
     @patch("argo_scg.sensu.Sensu.get_agents")
@@ -8233,22 +6685,14 @@ class SensuUsageChecksTests(unittest.TestCase):
         mock_post.assert_called_once_with(
             "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant1/checks",
             data=json.dumps(self.cpu_check),
-            headers={
-                "Authorization": "Key t0k3n",
-                "Content-Type": "application/json"
-            }
+            headers={"Authorization": "Key t0k3n", "Content-Type": "application/json"},
         )
-        self.assertEqual(
-            log.output,
-            [f"INFO:{LOGNAME}:tenant1: Check sensu.cpu.usage created"]
-        )
+        self.assertEqual(log.output, [f"INFO:{LOGNAME}:tenant1: Check sensu.cpu.usage created"])
 
     @patch("argo_scg.sensu.Sensu.get_agents")
     @patch("argo_scg.sensu.requests.post")
     @patch("argo_scg.sensu.Sensu._get_checks")
-    def test_add_cpu_check_with_error_with_message(
-            self, mock_get, mock_post, mock_agents
-    ):
+    def test_add_cpu_check_with_error_with_message(self, mock_get, mock_post, mock_agents):
         copy_mock_checks = mock_checks.copy()[0:3]
         mock_get.return_value = copy_mock_checks
         mock_post.side_effect = mock_post_response_not_ok_with_msg
@@ -8260,29 +6704,25 @@ class SensuUsageChecksTests(unittest.TestCase):
         mock_post.assert_called_once_with(
             "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant1/checks",
             data=json.dumps(self.cpu_check),
-            headers={
-                "Authorization": "Key t0k3n",
-                "Content-Type": "application/json"
-            }
+            headers={"Authorization": "Key t0k3n", "Content-Type": "application/json"},
         )
         self.assertEqual(
             context.exception.__str__(),
             "Sensu error: tenant1: Check sensu.cpu.usage not created: "
-            "400 BAD REQUEST: Something went wrong."
+            "400 BAD REQUEST: Something went wrong.",
         )
         self.assertEqual(
-            log.output, [
+            log.output,
+            [
                 f"ERROR:{LOGNAME}:tenant1: Check sensu.cpu.usage not created: "
                 f"400 BAD REQUEST: Something went wrong."
-            ]
+            ],
         )
 
     @patch("argo_scg.sensu.Sensu.get_agents")
     @patch("argo_scg.sensu.requests.post")
     @patch("argo_scg.sensu.Sensu._get_checks")
-    def test_add_cpu_check_with_error_without_message(
-            self, mock_get, mock_post, mock_agents
-    ):
+    def test_add_cpu_check_with_error_without_message(self, mock_get, mock_post, mock_agents):
         copy_mock_checks = mock_checks.copy()[0:3]
         mock_get.return_value = copy_mock_checks
         mock_post.side_effect = mock_post_response_not_ok_without_msg
@@ -8294,30 +6734,22 @@ class SensuUsageChecksTests(unittest.TestCase):
         mock_post.assert_called_once_with(
             "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant1/checks",
             data=json.dumps(self.cpu_check),
-            headers={
-                "Authorization": "Key t0k3n",
-                "Content-Type": "application/json"
-            }
+            headers={"Authorization": "Key t0k3n", "Content-Type": "application/json"},
         )
         self.assertEqual(
             context.exception.__str__(),
-            "Sensu error: tenant1: Check sensu.cpu.usage not created: "
-            "400 BAD REQUEST"
+            "Sensu error: tenant1: Check sensu.cpu.usage not created: 400 BAD REQUEST",
         )
         self.assertEqual(
-            log.output, [
-                f"ERROR:{LOGNAME}:tenant1: Check sensu.cpu.usage not created: "
-                f"400 BAD REQUEST"
-            ]
+            log.output,
+            [f"ERROR:{LOGNAME}:tenant1: Check sensu.cpu.usage not created: 400 BAD REQUEST"],
         )
 
     @patch("argo_scg.sensu.Sensu.get_agents")
     @patch("argo_scg.sensu.requests.put")
     @patch("argo_scg.sensu.requests.post")
     @patch("argo_scg.sensu.Sensu._get_checks")
-    def test_add_cpu_check_if_exists_and_same(
-            self, mock_get, mock_post, mock_put, mock_agents
-    ):
+    def test_add_cpu_check_if_exists_and_same(self, mock_get, mock_post, mock_put, mock_agents):
         mock_get.return_value = mock_checks
         mock_agents.return_value = [mock_entities[3], mock_entities[4]]
         with self.assertLogs(LOGNAME) as log:
@@ -8333,7 +6765,7 @@ class SensuUsageChecksTests(unittest.TestCase):
     @patch("argo_scg.sensu.requests.post")
     @patch("argo_scg.sensu.Sensu._get_checks")
     def test_add_cpu_check_if_exists_and_different(
-            self, mock_get, mock_post, mock_put, mock_agents
+        self, mock_get, mock_post, mock_put, mock_agents
     ):
         mock_checks_copy = mock_checks.copy()
         mock_checks_copy[3] = {
@@ -8343,12 +6775,8 @@ class SensuUsageChecksTests(unittest.TestCase):
             "interval": 300,
             "low_flap_threshold": 0,
             "publish": True,
-            "runtime_assets": [
-                "check-cpu-usage"
-            ],
-            "subscriptions": [
-                "entity:sensu-agent1"
-            ],
+            "runtime_assets": ["check-cpu-usage"],
+            "subscriptions": ["entity:sensu-agent1"],
             "proxy_entity_name": "",
             "check_hooks": None,
             "stdin": False,
@@ -8359,19 +6787,9 @@ class SensuUsageChecksTests(unittest.TestCase):
             "output_metric_format": "",
             "output_metric_handlers": None,
             "env_vars": None,
-            "metadata": {
-                "name": "sensu.cpu.usage",
-                "namespace": "tenant1",
-                "created_by": "admin"
-            },
+            "metadata": {"name": "sensu.cpu.usage", "namespace": "tenant1", "created_by": "admin"},
             "secrets": None,
-            "pipelines": [
-                {
-                    "name": "slack",
-                    "type": "Pipeline",
-                    "api_version": "core/v2"
-                }
-            ]
+            "pipelines": [{"name": "slack", "type": "Pipeline", "api_version": "core/v2"}],
         }
         mock_get.return_value = mock_checks_copy
         mock_put.side_effect = mock_post_response
@@ -8381,27 +6799,17 @@ class SensuUsageChecksTests(unittest.TestCase):
         mock_get.assert_called_once_with(namespace="tenant1")
         self.assertFalse(mock_post.called)
         mock_put.assert_called_once_with(
-            "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant1/checks/"
-            "sensu.cpu.usage",
+            "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant1/checks/sensu.cpu.usage",
             data=json.dumps(self.cpu_check),
-            headers={
-                "Authorization": "Key t0k3n",
-                "Content-Type": "application/json"
-            }
+            headers={"Authorization": "Key t0k3n", "Content-Type": "application/json"},
         )
-        self.assertEqual(
-            log.output, [
-                f"INFO:{LOGNAME}:tenant1: Check sensu.cpu.usage updated"
-            ]
-        )
+        self.assertEqual(log.output, [f"INFO:{LOGNAME}:tenant1: Check sensu.cpu.usage updated"])
 
     @patch("argo_scg.sensu.Sensu.get_agents")
     @patch("argo_scg.sensu.requests.put")
     @patch("argo_scg.sensu.requests.post")
     @patch("argo_scg.sensu.Sensu._get_checks")
-    def test_update_cpu_check_error_with_message(
-            self, mock_get, mock_post, mock_put, mock_agents
-    ):
+    def test_update_cpu_check_error_with_message(self, mock_get, mock_post, mock_put, mock_agents):
         mock_checks_copy = mock_checks.copy()
         mock_checks_copy[3] = {
             "command": "check-cpu-usage -w 75 -c 90",
@@ -8410,12 +6818,8 @@ class SensuUsageChecksTests(unittest.TestCase):
             "interval": 300,
             "low_flap_threshold": 0,
             "publish": True,
-            "runtime_assets": [
-                "check-cpu-usage"
-            ],
-            "subscriptions": [
-                "entity:sensu-agent1"
-            ],
+            "runtime_assets": ["check-cpu-usage"],
+            "subscriptions": ["entity:sensu-agent1"],
             "proxy_entity_name": "",
             "check_hooks": None,
             "stdin": False,
@@ -8426,19 +6830,9 @@ class SensuUsageChecksTests(unittest.TestCase):
             "output_metric_format": "",
             "output_metric_handlers": None,
             "env_vars": None,
-            "metadata": {
-                "name": "sensu.cpu.usage",
-                "namespace": "tenant1",
-                "created_by": "admin"
-            },
+            "metadata": {"name": "sensu.cpu.usage", "namespace": "tenant1", "created_by": "admin"},
             "secrets": None,
-            "pipelines": [
-                {
-                    "name": "slack",
-                    "type": "Pipeline",
-                    "api_version": "core/v2"
-                }
-            ]
+            "pipelines": [{"name": "slack", "type": "Pipeline", "api_version": "core/v2"}],
         }
         mock_get.return_value = mock_checks_copy
         mock_put.side_effect = mock_post_response_not_ok_with_msg
@@ -8449,24 +6843,21 @@ class SensuUsageChecksTests(unittest.TestCase):
         mock_get.assert_called_once_with(namespace="tenant1")
         self.assertFalse(mock_post.called)
         mock_put.assert_called_once_with(
-            "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant1/checks/"
-            "sensu.cpu.usage",
+            "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant1/checks/sensu.cpu.usage",
             data=json.dumps(self.cpu_check),
-            headers={
-                "Authorization": "Key t0k3n",
-                "Content-Type": "application/json"
-            }
+            headers={"Authorization": "Key t0k3n", "Content-Type": "application/json"},
         )
         self.assertEqual(
             context.exception.__str__(),
             "Sensu error: tenant1: Check sensu.cpu.usage not updated: "
-            "400 BAD REQUEST: Something went wrong."
+            "400 BAD REQUEST: Something went wrong.",
         )
         self.assertEqual(
-            log.output, [
+            log.output,
+            [
                 f"ERROR:{LOGNAME}:tenant1: Check sensu.cpu.usage not updated: "
                 f"400 BAD REQUEST: Something went wrong."
-            ]
+            ],
         )
 
     @patch("argo_scg.sensu.Sensu.get_agents")
@@ -8474,7 +6865,7 @@ class SensuUsageChecksTests(unittest.TestCase):
     @patch("argo_scg.sensu.requests.post")
     @patch("argo_scg.sensu.Sensu._get_checks")
     def test_update_cpu_check_error_without_message(
-            self, mock_get, mock_post, mock_put, mock_agents
+        self, mock_get, mock_post, mock_put, mock_agents
     ):
         mock_checks_copy = mock_checks.copy()
         mock_checks_copy[3] = {
@@ -8484,12 +6875,8 @@ class SensuUsageChecksTests(unittest.TestCase):
             "interval": 300,
             "low_flap_threshold": 0,
             "publish": True,
-            "runtime_assets": [
-                "check-cpu-usage"
-            ],
-            "subscriptions": [
-                "entity:sensu-agent1"
-            ],
+            "runtime_assets": ["check-cpu-usage"],
+            "subscriptions": ["entity:sensu-agent1"],
             "proxy_entity_name": "",
             "check_hooks": None,
             "stdin": False,
@@ -8500,19 +6887,9 @@ class SensuUsageChecksTests(unittest.TestCase):
             "output_metric_format": "",
             "output_metric_handlers": None,
             "env_vars": None,
-            "metadata": {
-                "name": "sensu.cpu.usage",
-                "namespace": "tenant1",
-                "created_by": "admin"
-            },
+            "metadata": {"name": "sensu.cpu.usage", "namespace": "tenant1", "created_by": "admin"},
             "secrets": None,
-            "pipelines": [
-                {
-                    "name": "slack",
-                    "type": "Pipeline",
-                    "api_version": "core/v2"
-                }
-            ]
+            "pipelines": [{"name": "slack", "type": "Pipeline", "api_version": "core/v2"}],
         }
         mock_get.return_value = mock_checks_copy
         mock_put.side_effect = mock_post_response_not_ok_without_msg
@@ -8523,24 +6900,17 @@ class SensuUsageChecksTests(unittest.TestCase):
         mock_get.assert_called_once_with(namespace="tenant1")
         self.assertFalse(mock_post.called)
         mock_put.assert_called_once_with(
-            "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant1/checks/"
-            "sensu.cpu.usage",
+            "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant1/checks/sensu.cpu.usage",
             data=json.dumps(self.cpu_check),
-            headers={
-                "Authorization": "Key t0k3n",
-                "Content-Type": "application/json"
-            }
+            headers={"Authorization": "Key t0k3n", "Content-Type": "application/json"},
         )
         self.assertEqual(
             context.exception.__str__(),
-            "Sensu error: tenant1: Check sensu.cpu.usage not updated: "
-            "400 BAD REQUEST"
+            "Sensu error: tenant1: Check sensu.cpu.usage not updated: 400 BAD REQUEST",
         )
         self.assertEqual(
-            log.output, [
-                f"ERROR:{LOGNAME}:tenant1: Check sensu.cpu.usage not updated: "
-                f"400 BAD REQUEST"
-            ]
+            log.output,
+            [f"ERROR:{LOGNAME}:tenant1: Check sensu.cpu.usage not updated: 400 BAD REQUEST"],
         )
 
     @patch("argo_scg.sensu.Sensu.get_agents")
@@ -8557,22 +6927,14 @@ class SensuUsageChecksTests(unittest.TestCase):
         mock_post.assert_called_once_with(
             "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant1/checks",
             data=json.dumps(self.memory_check),
-            headers={
-                "Authorization": "Key t0k3n",
-                "Content-Type": "application/json"
-            }
+            headers={"Authorization": "Key t0k3n", "Content-Type": "application/json"},
         )
-        self.assertEqual(
-            log.output,
-            [f"INFO:{LOGNAME}:tenant1: Check sensu.memory.usage created"]
-        )
+        self.assertEqual(log.output, [f"INFO:{LOGNAME}:tenant1: Check sensu.memory.usage created"])
 
     @patch("argo_scg.sensu.Sensu.get_agents")
     @patch("argo_scg.sensu.requests.post")
     @patch("argo_scg.sensu.Sensu._get_checks")
-    def test_add_memory_check_with_error_with_message(
-            self, mock_get, mock_post, mock_agents
-    ):
+    def test_add_memory_check_with_error_with_message(self, mock_get, mock_post, mock_agents):
         mock_checks_copy = mock_checks.copy()
         mock_get.return_value = mock_checks_copy[0:3]
         mock_post.side_effect = mock_post_response_not_ok_with_msg
@@ -8584,29 +6946,25 @@ class SensuUsageChecksTests(unittest.TestCase):
         mock_post.assert_called_once_with(
             "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant1/checks",
             data=json.dumps(self.memory_check),
-            headers={
-                "Authorization": "Key t0k3n",
-                "Content-Type": "application/json"
-            }
+            headers={"Authorization": "Key t0k3n", "Content-Type": "application/json"},
         )
         self.assertEqual(
             context.exception.__str__(),
             "Sensu error: tenant1: Check sensu.memory.usage not created: "
-            "400 BAD REQUEST: Something went wrong."
+            "400 BAD REQUEST: Something went wrong.",
         )
         self.assertEqual(
-            log.output, [
+            log.output,
+            [
                 f"ERROR:{LOGNAME}:tenant1: Check sensu.memory.usage not "
                 f"created: 400 BAD REQUEST: Something went wrong."
-            ]
+            ],
         )
 
     @patch("argo_scg.sensu.Sensu.get_agents")
     @patch("argo_scg.sensu.requests.post")
     @patch("argo_scg.sensu.Sensu._get_checks")
-    def test_add_memory_check_with_error_without_message(
-            self, mock_get, mock_post, mock_agents
-    ):
+    def test_add_memory_check_with_error_without_message(self, mock_get, mock_post, mock_agents):
         mock_checks_copy = mock_checks.copy()
         mock_get.return_value = mock_checks_copy[0:3]
         mock_post.side_effect = mock_post_response_not_ok_without_msg
@@ -8618,30 +6976,22 @@ class SensuUsageChecksTests(unittest.TestCase):
         mock_post.assert_called_once_with(
             "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant1/checks",
             data=json.dumps(self.memory_check),
-            headers={
-                "Authorization": "Key t0k3n",
-                "Content-Type": "application/json"
-            }
+            headers={"Authorization": "Key t0k3n", "Content-Type": "application/json"},
         )
         self.assertEqual(
             context.exception.__str__(),
-            "Sensu error: tenant1: Check sensu.memory.usage not created: "
-            "400 BAD REQUEST"
+            "Sensu error: tenant1: Check sensu.memory.usage not created: 400 BAD REQUEST",
         )
         self.assertEqual(
-            log.output, [
-                f"ERROR:{LOGNAME}:tenant1: Check sensu.memory.usage not "
-                f"created: 400 BAD REQUEST"
-            ]
+            log.output,
+            [f"ERROR:{LOGNAME}:tenant1: Check sensu.memory.usage not created: 400 BAD REQUEST"],
         )
 
     @patch("argo_scg.sensu.Sensu.get_agents")
     @patch("argo_scg.sensu.requests.put")
     @patch("argo_scg.sensu.requests.post")
     @patch("argo_scg.sensu.Sensu._get_checks")
-    def test_add_memory_check_if_exists_and_same(
-            self, mock_get, mock_post, mock_put, mock_agents
-    ):
+    def test_add_memory_check_if_exists_and_same(self, mock_get, mock_post, mock_put, mock_agents):
         mock_get.return_value = mock_checks
         mock_agents.return_value = [mock_entities[3]]
         with self.assertLogs(LOGNAME) as log:
@@ -8657,7 +7007,7 @@ class SensuUsageChecksTests(unittest.TestCase):
     @patch("argo_scg.sensu.requests.post")
     @patch("argo_scg.sensu.Sensu._get_checks")
     def test_add_memory_check_if_exists_and_different(
-            self, mock_get, mock_post, mock_put, mock_agents
+        self, mock_get, mock_post, mock_put, mock_agents
     ):
         mock_checks_copy = mock_checks.copy()
         mock_checks_copy[4] = {
@@ -8667,12 +7017,8 @@ class SensuUsageChecksTests(unittest.TestCase):
             "interval": 300,
             "low_flap_threshold": 0,
             "publish": True,
-            "runtime_assets": [
-                "check-memory-usage"
-            ],
-            "subscriptions": [
-                "entity:sensu-agent1"
-            ],
+            "runtime_assets": ["check-memory-usage"],
+            "subscriptions": ["entity:sensu-agent1"],
             "proxy_entity_name": "",
             "check_hooks": None,
             "stdin": False,
@@ -8686,16 +7032,10 @@ class SensuUsageChecksTests(unittest.TestCase):
             "metadata": {
                 "name": "sensu.memory.usage",
                 "namespace": "tenant1",
-                "created_by": "admin"
+                "created_by": "admin",
             },
             "secrets": None,
-            "pipelines": [
-                {
-                    "name": "slack",
-                    "type": "Pipeline",
-                    "api_version": "core/v2"
-                }
-            ]
+            "pipelines": [{"name": "slack", "type": "Pipeline", "api_version": "core/v2"}],
         }
         mock_get.return_value = mock_checks_copy
         mock_put.side_effect = mock_post_response
@@ -8705,26 +7045,18 @@ class SensuUsageChecksTests(unittest.TestCase):
         mock_get.assert_called_once_with(namespace="tenant1")
         self.assertFalse(mock_post.called)
         mock_put.assert_called_once_with(
-            "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant1/checks/"
-            "sensu.memory.usage",
+            "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant1/checks/sensu.memory.usage",
             data=json.dumps(self.memory_check),
-            headers={
-                "Authorization": "Key t0k3n",
-                "Content-Type": "application/json"
-            }
+            headers={"Authorization": "Key t0k3n", "Content-Type": "application/json"},
         )
-        self.assertEqual(
-            log.output, [
-                f"INFO:{LOGNAME}:tenant1: Check sensu.memory.usage updated"
-            ]
-        )
+        self.assertEqual(log.output, [f"INFO:{LOGNAME}:tenant1: Check sensu.memory.usage updated"])
 
     @patch("argo_scg.sensu.Sensu.get_agents")
     @patch("argo_scg.sensu.requests.put")
     @patch("argo_scg.sensu.requests.post")
     @patch("argo_scg.sensu.Sensu._get_checks")
     def test_update_memory_check_error_with_message(
-            self, mock_get, mock_post, mock_put, mock_agents
+        self, mock_get, mock_post, mock_put, mock_agents
     ):
         mock_checks_copy = mock_checks.copy()
         mock_checks_copy[4] = {
@@ -8734,12 +7066,8 @@ class SensuUsageChecksTests(unittest.TestCase):
             "interval": 300,
             "low_flap_threshold": 0,
             "publish": True,
-            "runtime_assets": [
-                "check-memory-usage"
-            ],
-            "subscriptions": [
-                "entity:sensu-agent1"
-            ],
+            "runtime_assets": ["check-memory-usage"],
+            "subscriptions": ["entity:sensu-agent1"],
             "proxy_entity_name": "",
             "check_hooks": None,
             "stdin": False,
@@ -8753,16 +7081,10 @@ class SensuUsageChecksTests(unittest.TestCase):
             "metadata": {
                 "name": "sensu.memory.usage",
                 "namespace": "tenant1",
-                "created_by": "admin"
+                "created_by": "admin",
             },
             "secrets": None,
-            "pipelines": [
-                {
-                    "name": "slack",
-                    "type": "Pipeline",
-                    "api_version": "core/v2"
-                }
-            ]
+            "pipelines": [{"name": "slack", "type": "Pipeline", "api_version": "core/v2"}],
         }
         mock_get.return_value = mock_checks_copy
         mock_put.side_effect = mock_post_response_not_ok_with_msg
@@ -8773,24 +7095,21 @@ class SensuUsageChecksTests(unittest.TestCase):
         mock_get.assert_called_once_with(namespace="tenant1")
         self.assertFalse(mock_post.called)
         mock_put.assert_called_once_with(
-            "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant1/checks/"
-            "sensu.memory.usage",
+            "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant1/checks/sensu.memory.usage",
             data=json.dumps(self.memory_check),
-            headers={
-                "Authorization": "Key t0k3n",
-                "Content-Type": "application/json"
-            }
+            headers={"Authorization": "Key t0k3n", "Content-Type": "application/json"},
         )
         self.assertEqual(
             context.exception.__str__(),
             "Sensu error: tenant1: Check sensu.memory.usage not updated: "
-            "400 BAD REQUEST: Something went wrong."
+            "400 BAD REQUEST: Something went wrong.",
         )
         self.assertEqual(
-            log.output, [
+            log.output,
+            [
                 f"ERROR:{LOGNAME}:tenant1: Check sensu.memory.usage not "
                 f"updated: 400 BAD REQUEST: Something went wrong."
-            ]
+            ],
         )
 
     @patch("argo_scg.sensu.Sensu.get_agents")
@@ -8798,7 +7117,7 @@ class SensuUsageChecksTests(unittest.TestCase):
     @patch("argo_scg.sensu.requests.post")
     @patch("argo_scg.sensu.Sensu._get_checks")
     def test_update_memory_check_error_without_message(
-            self, mock_get, mock_post, mock_put, mock_agents
+        self, mock_get, mock_post, mock_put, mock_agents
     ):
         mock_checks_copy = mock_checks.copy()
         mock_checks_copy[4] = {
@@ -8808,12 +7127,8 @@ class SensuUsageChecksTests(unittest.TestCase):
             "interval": 300,
             "low_flap_threshold": 0,
             "publish": True,
-            "runtime_assets": [
-                "check-memory-usage"
-            ],
-            "subscriptions": [
-                "entity:sensu-agent1"
-            ],
+            "runtime_assets": ["check-memory-usage"],
+            "subscriptions": ["entity:sensu-agent1"],
             "proxy_entity_name": "",
             "check_hooks": None,
             "stdin": False,
@@ -8827,16 +7142,10 @@ class SensuUsageChecksTests(unittest.TestCase):
             "metadata": {
                 "name": "sensu.memory.usage",
                 "namespace": "tenant1",
-                "created_by": "admin"
+                "created_by": "admin",
             },
             "secrets": None,
-            "pipelines": [
-                {
-                    "name": "slack",
-                    "type": "Pipeline",
-                    "api_version": "core/v2"
-                }
-            ]
+            "pipelines": [{"name": "slack", "type": "Pipeline", "api_version": "core/v2"}],
         }
         mock_get.return_value = mock_checks_copy
         mock_put.side_effect = mock_post_response_not_ok_without_msg
@@ -8847,24 +7156,17 @@ class SensuUsageChecksTests(unittest.TestCase):
         mock_get.assert_called_once_with(namespace="tenant1")
         self.assertFalse(mock_post.called)
         mock_put.assert_called_once_with(
-            "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant1/checks/"
-            "sensu.memory.usage",
+            "https://sensu.mock.com:8080/api/core/v2/namespaces/tenant1/checks/sensu.memory.usage",
             data=json.dumps(self.memory_check),
-            headers={
-                "Authorization": "Key t0k3n",
-                "Content-Type": "application/json"
-            }
+            headers={"Authorization": "Key t0k3n", "Content-Type": "application/json"},
         )
         self.assertEqual(
             context.exception.__str__(),
-            "Sensu error: tenant1: Check sensu.memory.usage not updated: "
-            "400 BAD REQUEST"
+            "Sensu error: tenant1: Check sensu.memory.usage not updated: 400 BAD REQUEST",
         )
         self.assertEqual(
-            log.output, [
-                f"ERROR:{LOGNAME}:tenant1: Check sensu.memory.usage not "
-                f"updated: 400 BAD REQUEST"
-            ]
+            log.output,
+            [f"ERROR:{LOGNAME}:tenant1: Check sensu.memory.usage not updated: 400 BAD REQUEST"],
         )
 
 
@@ -8873,20 +7175,17 @@ class MetricOutputTests(unittest.TestCase):
         sample_output = {
             "check": {
                 "command": "/usr/lib64/nagios/plugins/check_http -H "
-                           "hostname.example.eu -t 60 --link "
-                           "--onredirect follow -S --sni -p 443 -u "
-                           "/index.php/services",
+                "hostname.example.eu -t 60 --link "
+                "--onredirect follow -S --sni -p 443 -u "
+                "/index.php/services",
                 "handlers": [],
                 "high_flap_threshold": 0,
                 "interval": 300,
                 "low_flap_threshold": 0,
                 "publish": True,
                 "runtime_assets": None,
-                "subscriptions": [
-                    "entity:sensu-agent1"
-                ],
-                "proxy_entity_name": "eu.eosc.portal.services.url__hostname."
-                                     "example.eu_site-name",
+                "subscriptions": ["entity:sensu-agent1"],
+                "proxy_entity_name": "eu.eosc.portal.services.url__hostname.example.eu_site-name",
                 "check_hooks": None,
                 "stdin": False,
                 "subdue": None,
@@ -8895,11 +7194,10 @@ class MetricOutputTests(unittest.TestCase):
                 "proxy_requests": {
                     "entity_attributes": [
                         "entity.entity_class == 'proxy'",
-                        "entity.labels.generic_http_connect == "
-                        "'generic.http.connect'"
+                        "entity.labels.generic_http_connect == 'generic.http.connect'",
                     ],
                     "splay": False,
-                    "splay_coverage": 0
+                    "splay_coverage": 0,
                 },
                 "round_robin": False,
                 "duration": 8.267622018,
@@ -8914,8 +7212,8 @@ class MetricOutputTests(unittest.TestCase):
                 ],
                 "issued": 1675328305,
                 "output": "TEXT OUTPUT|OPTIONAL PERFDATA\nLONG TEXT LINE 1\n"
-                          "LONG TEXT LINE 2\nLONG TEXT LINE 3|PERFDATA LINE 2\n"
-                          "PERFDATA LINE 3",
+                "LONG TEXT LINE 2\nLONG TEXT LINE 3|PERFDATA LINE 2\n"
+                "PERFDATA LINE 3",
                 "state": "passing",
                 "status": 0,
                 "total_state_change": 0,
@@ -8929,17 +7227,13 @@ class MetricOutputTests(unittest.TestCase):
                     "name": "generic.http.connect",
                     "namespace": "tenant",
                     "annotations": {"attempts": "3"},
-                    "labels": {"tenants": "TENANT"}
+                    "labels": {"tenants": "TENANT"},
                 },
                 "secrets": None,
                 "is_silenced": False,
                 "scheduler": "",
                 "processed_by": "sensu-agent.example.com",
-                "pipelines": [{
-                    "name": "hard_state",
-                    "type": "Pipeline",
-                    "api_version": "core/v2"
-                }]
+                "pipelines": [{"name": "hard_state", "type": "Pipeline", "api_version": "core/v2"}],
             },
             "entity": {
                 "entity_class": "proxy",
@@ -8949,272 +7243,253 @@ class MetricOutputTests(unittest.TestCase):
                     "vm_system": "",
                     "vm_role": "",
                     "cloud_provider": "",
-                    "processes": None
+                    "processes": None,
                 },
-                "subscriptions": [
-                    "entity:sensu-agent1"
-                ],
+                "subscriptions": ["entity:sensu-agent1"],
                 "last_seen": 0,
                 "deregister": False,
                 "deregistration": {},
                 "metadata": {
-                    "name": "eu.eosc.portal.services.url__hostname.example.eu_"
-                            "site-name",
+                    "name": "eu.eosc.portal.services.url__hostname.example.eu_site-name",
                     "namespace": "tenant",
                     "labels": {
                         "generic_http_connect": "generic.http.connect",
                         "hostname": "hostname.example.eu",
-                        "info_url":
-                            "https://hostname.example.eu/index.php/services",
+                        "info_url": "https://hostname.example.eu/index.php/services",
                         "path": "/index.php/services",
                         "port": "443",
                         "service": "eu.eosc.portal.services.url",
                         "site": "site-name",
                         "ngi": "NGI_TEST",
                         "ssl": "-S --sni",
-                        "tenants": "TENANT"
-                    }
+                        "tenants": "TENANT",
+                    },
                 },
-                "sensu_agent_version": ""
+                "sensu_agent_version": "",
             },
             "id": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
             "metadata": {"namespace": "tenant"},
-            "pipelines": [{
-                "name": "hard_state",
-                "type": "Pipeline",
-                "api_version": "core/v2"
-            }],
+            "pipelines": [{"name": "hard_state", "type": "Pipeline", "api_version": "core/v2"}],
             "sequence": 7371,
-            "timestamp": 1675328313
+            "timestamp": 1675328313,
         }
         sample_output_one_line = copy.deepcopy(sample_output)
         sample_output_one_line_with_perfdata = copy.deepcopy(sample_output)
         sample_output_multiline_no_perfdata = copy.deepcopy(sample_output)
         sample_output_one_line["check"]["output"] = "TEXT OUTPUT"
-        sample_output_one_line_with_perfdata["check"]["output"] = \
-            "TEXT OUTPUT|OPTIONAL PERFDATA"
-        sample_output_multiline_no_perfdata["check"]["output"] = \
+        sample_output_one_line_with_perfdata["check"]["output"] = "TEXT OUTPUT|OPTIONAL PERFDATA"
+        sample_output_multiline_no_perfdata["check"]["output"] = (
             "TEXT OUTPUT\nLONG TEXT LINE 1\nLONG TEXT LINE 2\nLONG TEXT LINE 3"
+        )
         sample_output_multiline_with_breaks = copy.deepcopy(sample_output)
-        sample_output_multiline_with_breaks["check"]["output"] = \
-            ("OK - Job successfully completed\\n=== ETF job log:\\nTimeout "
-             "limits configured were:\\n=== Credentials:\\nx509:\\n/DC=EU/DC="
-             "EGI/C=HR/O=Robots/O=SRCE/CN=Robot:argo-egi@cro-ngi.hr/CN="
-             "605601970\n\\n/ops/Role=NULL/Capability=NULL\n\\n\\n=== Job "
-             "description:\\nJDL([('universe', 'vanilla'), ('executable', "
-             "'hostname'), ('transfer_executable', 'true'), ('output', "
-             "'/var/lib/gridprobes/ops/scondor/alict-ce-01.ct.infn.it/out/"
-             "gridjob.out'), ('error', '/var/lib/gridprobes/ops/scondor/"
-             "alict-ce-01.ct.infn.it/out/gridjob.err'), ('log', '/var/lib/"
-             "gridprobes/ops/scondor/alict-ce-01.ct.infn.it/out/gridjob.log'), "
-             "('log_xml', 'true'), ('should_transfer_files', 'YES'), "
-             "('when_to_transfer_output', 'ON_EXIT'), ('use_x509userproxy', "
-             "'true')])\\n=== Job submission command:\\ncondor_submit --spool "
-             "--name alict-ce-01.ct.infn.it --pool alict-ce-01.ct.infn.it:9619 "
-             "/var/lib/gridprobes/ops/scondor/alict-ce-01.ct.infn.it/"
-             "gridjob.jdl\\nSubmitting job(s).\n\\n1 job(s) submitted to "
-             "cluster 1538415.\n\\n\\n=== Job log:\\nArguments = \"\"\n\\n"
-             "BytesRecvd = 15784.0\n\\nBytesSent = 24.0\n\\nClusterId = "
-             "1538415\n\\nCmd = \"hostname\"\n\\nCommittedSlotTime = 0\n\\n"
-             "CommittedSuspensionTime = 0\n\\nCommittedTime = 0\n\\n"
-             "CompletionDate = 1705930181\n\\nCondorPlatform = "
-             "\"$CondorPlatform: x86_64_CentOS7 $\"\n\\nCondorVersion = "
-             "\"$CondorVersion: 9.0.20 Nov 15 2023 BuildID: 690225 PackageID: "
-             "9.0.20-1 $\"\n\\nCoreSize = 0\n\\nCumulativeRemoteSysCpu = 0.0"
-             "\n\\nCumulativeRemoteUserCpu = 0.0\n\\nCumulativeSlotTime = 0"
-             "\n\\nCumulativeSuspensionTime = 0\n\\nCurrentHosts = 0\n\\n"
-             "DiskUsage = 40\n\\nDiskUsage_RAW = 40\n\\n"
-             "EncryptExecuteDirectory = false\n\\nEnteredCurrentStatus = "
-             "1705608983\n\\nEnvironment = \"\"\n\\nErr = \"_condor_stderr\""
-             "\n\\nExecutableSize = 17\n\\nExecutableSize_RAW = 16\n\\n"
-             "ExitBySignal = false\n\\nExitCode = 0\n\\nExitStatus = 0\n\\n"
-             "GlobalJobId = \"alict-ce-01.ct.infn.it#1538415.0#1705608982\""
-             "\n\\nHoldReason = undefined\n\\nHoldReasonCode = undefined\n\\n"
-             "ImageSize = 17\n\\nImageSize_RAW = 16\n\\nIn = \"/dev/null\""
-             "\n\\nIwd = \"/var/lib/condor-ce/spool/8415/0/cluster1538415."
-             "proc0.subproc0\"\n\\nJobCurrentStartDate = 1705930179\n\\n"
-             "JobCurrentStartExecutingDate = 1705930180\n\\n"
-             "JobFinishedHookDone = 1705930203\n\\nJobLeaseDuration = 2400"
-             "\n\\nJobNotification = 0\n\\nJobPrio = 0\n\\nJobRunCount = 1"
-             "\n\\nJobStartDate = 1705930179\n\\nJobStatus = 4\n\\n"
-             "JobUniverse = 5\n\\nLastHoldReason = \"Spooling input data "
-             "files\"\n\\nLastHoldReasonCode = 16\n\\nLastJobStatus = 1\n\\n"
-             "LastSuspensionTime = 0\n\\nLeaveJobInQueue = JobStatus == 4 && "
-             "(CompletionDate =?= undefined \\u2758\\u2758 CompletionDate == 0 "
-             "\\u2758\\u2758 ((time() - CompletionDate) < 864000))\n\\n"
-             "Managed = \"ScheddDone\"\n\\nManagedManager = \"\"\n\\n"
-             "MaxHosts = 1\n\\nMemoryUsage = ((ResidentSetSize + 1023) / "
-             "1024)\n\\nMinHosts = 1\n\\nMyType = \"Job\"\n\\nNumCkpts = 0"
-             "\n\\nNumCkpts_RAW = 0\n\\nNumJobCompletions = 0\n\\n"
-             "NumJobMatches = 1\n\\nNumJobStarts = 1\n\\nNumRestarts = 0\n\\n"
-             "NumShadowStarts = 1\n\\nNumSystemHolds = 0\n\\nOnExitHold = false"
-             "\n\\nOnExitRemove = true\n\\nOut = \"_condor_stdout\"\n\\n"
-             "Owner = \"ops008\"\n\\nPeriodicHold = false\n\\nPeriodicRelease ="
-             " false\n\\nPeriodicRemove = false\n\\nProcId = 0\n\\nQDate = "
-             "1705608981\n\\nRank = 0.0\n\\nReleaseReason = \"Data files "
-             "spooled\"\n\\nRemoteSysCpu = 0.0\n\\nRemoteUserCpu = 0.0\n\\n"
-             "RemoteWallClockTime = 2.0\n\\nRequestCpus = 1\n\\nRequestDisk = "
-             "DiskUsage\n\\nRequestMemory = ifthenelse(MemoryUsage =!= "
-             "undefined,MemoryUsage,(ImageSize + 1023) / 1024)\n\\n"
-             "Requirements = (TARGET.Arch == \"X86_64\") && (TARGET.OpSys == "
-             "\"LINUX\") && (TARGET.Disk >= RequestDisk) && (TARGET.Memory >= "
-             "RequestMemory) && (TARGET.HasFileTransfer)\n\\nResidentSetSize "
-             "= 0\n\\nResidentSetSize_RAW = 0\n\\nRootDir = \"/\"\n\\n"
-             "RoutedToJobId = \"1537363.0\"\n\\nScratchDirFileCount = 10\n\\n"
-             "ServerTime = 1705932987\n\\nShouldTransferFiles = \"YES\"\n\\n"
-             "SpooledOutputFiles = \"\"\n\\nStageInFinish = 1705608982\n\\n"
-             "StageInStart = 1705608982\n\\nStreamErr = false\n\\nStreamOut = "
-             "false\n\\nSUBMIT_Cmd = \"/var/lib/gridprobes/ops/scondor/"
-             "alict-ce-01.ct.infn.it/hostname\"\n\\nSUBMIT_Iwd = \"/var/lib/"
-             "gridprobes/ops/scondor/alict-ce-01.ct.infn.it\"\n\\nSUBMIT_"
-             "TransferOutputRemaps = \"_condor_stdout=/var/lib/gridprobes/ops/"
-             "scondor/alict-ce-01.ct.infn.it/out/gridjob.out;_condor_stderr=/"
-             "var/lib/gridprobes/ops/scondor/alict-ce-01.ct.infn.it/out/"
-             "gridjob.err\"\n\\nSUBMIT_UserLog = \"/var/lib/gridprobes/ops/"
-             "scondor/alict-ce-01.ct.infn.it/out/gridjob.log\"\n\\nSUBMIT_"
-             "x509userproxy = \"/etc/sensu/certs/userproxy.pem\"\n\\n"
-             "TargetType = \"Machine\"\n\\nTotalSubmitProcs = 1\n\\n"
-             "TotalSuspensions = 0\n\\nTransferIn = false\n\\n"
-             "TransferInputSizeMB = 0\n\\nTransferOutputRemaps = undefined"
-             "\n\\nUser = \"ops008@T2HTC\"\n\\nUserLog = \"gridjob.log\"\n\\n"
-             "UserLogUseXML = true\n\\nWantCheckpoint = false\n\\n"
-             "WantRemoteIO = true\n\\nWantRemoteSyscalls = false\n\\n"
-             "WhenToTransferOutput = \"ON_EXIT\"\n\\nx509userproxy = "
-             "\"userproxy.pem\"\n\\nx509UserProxyEmail = \"argo-egi@cro-ngi.hr"
-             "\"\n\\nx509UserProxyExpiration = 1705651369\n\\n"
-             "x509UserProxyFirstFQAN = \"/ops/Role=NULL/Capability=NULL\"\n\\n"
-             "x509UserProxyFQAN = \"/DC=EU/DC=EGI/C=HR/O=Robots/O=SRCE/CN="
-             "Robot:argo-egi@cro-ngi.hr,/ops/Role=NULL/Capability=NULL\"\n\\n"
-             "x509userproxysubject = \"/DC=EU/DC=EGI/C=HR/O=Robots/O=SRCE/CN="
-             "Robot:argo-egi@cro-ngi.hr\"\n\\nx509UserProxyVOName = \"ops\""
-             "\n\\n\n\\n\\n=== Last job status:\\nArguments = \"\"\n\\n"
-             "BytesRecvd = 15784.0\n\\nBytesSent = 24.0\n\\nClusterId = 1538415"
-             "\n\\nCmd = \"hostname\"\n\\nCommittedSlotTime = 0\n\\n"
-             "CommittedSuspensionTime = 0\n\\nCommittedTime = 0\n\\n"
-             "CompletionDate = 1705930181\n\\nCondorPlatform = "
-             "\"$CondorPlatform: x86_64_CentOS7 $\"\n\\nCondorVersion = "
-             "\"$CondorVersion: 9.0.20 Nov 15 2023 BuildID: 690225 PackageID: "
-             "9.0.20-1 $\"\n\\nCoreSize = 0\n\\nCumulativeRemoteSysCpu = 0.0"
-             "\n\\nCumulativeRemoteUserCpu = 0.0\n\\nCumulativeSlotTime = 0"
-             "\n\\nCumulativeSuspensionTime = 0\n\\nCurrentHosts = 0\n\\n"
-             "DiskUsage = 40\n\\nDiskUsage_RAW = 40\n\\n"
-             "EncryptExecuteDirectory = false\n\\nEnteredCurrentStatus = "
-             "1705608983\n\\nEnvironment = \"\"\n\\nErr = \"_condor_stderr"
-             "\"\n\\nExecutableSize = 17\n\\nExecutableSize_RAW = 16\n\\n"
-             "ExitBySignal = false\n\\nExitCode = 0\n\\nExitStatus = 0\n\\n"
-             "GlobalJobId = \"alict-ce-01.ct.infn.it#1538415.0#1705608982"
-             "\"\n\\nHoldReason = undefined\n\\nHoldReasonCode = undefined"
-             "\n\\nImageSize = 17\n\\nImageSize_RAW = 16\n\\nIn = \"/dev/null"
-             "\"\n\\nIwd = \"/var/lib/condor-ce/spool/8415/0/cluster1538415."
-             "proc0.subproc0\"\n\\nJobCurrentStartDate = 1705930179\n\\n"
-             "JobCurrentStartExecutingDate = 1705930180\n\\n"
-             "JobFinishedHookDone = 1705930203\n\\nJobLeaseDuration = 2400\n\\n"
-             "JobNotification = 0\n\\nJobPrio = 0\n\\nJobRunCount = 1\n\\n"
-             "JobStartDate = 1705930179\n\\nJobStatus = 4\n\\nJobUniverse = 5"
-             "\n\\nLastHoldReason = \"Spooling input data files\"\n\\n"
-             "LastHoldReasonCode = 16\n\\nLastJobStatus = 1\n\\n"
-             "LastSuspensionTime = 0\n\\nLeaveJobInQueue = JobStatus == 4 && "
-             "(CompletionDate =?= undefined \\u2758\\u2758 CompletionDate == 0"
-             " \\u2758\\u2758 ((time() - CompletionDate) < 864000))\n\\n"
-             "Managed = \"ScheddDone\"\n\\nManagedManager = \"\"\n\\n"
-             "MaxHosts = 1\n\\nMemoryUsage = ((ResidentSetSize + 1023) / 1024)"
-             "\n\\nMinHosts = 1\n\\nMyType = \"Job\"\n\\nNumCkpts = 0\n\\n"
-             "NumCkpts_RAW = 0\n\\nNumJobCompletions = 0\n\\nNumJobMatches = 1"
-             "\n\\nNumJobStarts = 1\n\\nNumRestarts = 0\n\\nNumShadowStarts = 1"
-             "\n\\nNumSystemHolds = 0\n\\nOnExitHold = false\n\\nOnExitRemove "
-             "= true\n\\nOut = \"_condor_stdout\"\n\\nOwner = \"ops008\"\n\\n"
-             "PeriodicHold = false\n\\nPeriodicRelease = false\n\\n"
-             "PeriodicRemove = false\n\\nProcId = 0\n\\nQDate = 1705608981\n\\n"
-             "Rank = 0.0\n\\nReleaseReason = \"Data files spooled\"\n\\n"
-             "RemoteSysCpu = 0.0\n\\nRemoteUserCpu = 0.0\n\\n"
-             "RemoteWallClockTime = 2.0\n\\nRequestCpus = 1\n\\nRequestDisk = "
-             "DiskUsage\n\\nRequestMemory = ifthenelse(MemoryUsage =!= "
-             "undefined,MemoryUsage,(ImageSize + 1023) / 1024)\n\\n"
-             "Requirements = (TARGET.Arch == \"X86_64\") && (TARGET.OpSys == "
-             "\"LINUX\") && (TARGET.Disk >= RequestDisk) && (TARGET.Memory >= "
-             "RequestMemory) && (TARGET.HasFileTransfer)\n\\nResidentSetSize "
-             "= 0\n\\nResidentSetSize_RAW = 0\n\\nRootDir = \"/\"\n\\n"
-             "RoutedToJobId = \"1537363.0\"\n\\nScratchDirFileCount = 10\n\\n"
-             "ServerTime = 1705932985\n\\nShouldTransferFiles = \"YES\"\n\\n"
-             "SpooledOutputFiles = \"\"\n\\nStageInFinish = 1705608982\n\\n"
-             "StageInStart = 1705608982\n\\nStreamErr = false\n\\nStreamOut = "
-             "false\n\\nSUBMIT_Cmd = \"/var/lib/gridprobes/ops/scondor/"
-             "alict-ce-01.ct.infn.it/hostname\"\n\\nSUBMIT_Iwd = \"/var/lib/"
-             "gridprobes/ops/scondor/alict-ce-01.ct.infn.it\"\n\\nSUBMIT_"
-             "TransferOutputRemaps = \"_condor_stdout=/var/lib/gridprobes/ops/"
-             "scondor/alict-ce-01.ct.infn.it/out/gridjob.out;_condor_stderr="
-             "/var/lib/gridprobes/ops/scondor/alict-ce-01.ct.infn.it/out/"
-             "gridjob.err\"\n\\nSUBMIT_UserLog = \"/var/lib/gridprobes/ops/"
-             "scondor/alict-ce-01.ct.infn.it/out/gridjob.log\"\n\\nSUBMIT_"
-             "x509userproxy = \"/etc/sensu/certs/userproxy.pem\"\n\\n"
-             "TargetType = \"Machine\"\n\\nTotalSubmitProcs = 1\n\\n"
-             "TotalSuspensions = 0\n\\nTransferIn = false\n\\n"
-             "TransferInputSizeMB = 0\n\\nTransferOutputRemaps = undefined\n\\n"
-             "User = \"ops008@T2HTC\"\n\\nUserLog = \"gridjob.log\"\n\\n"
-             "UserLogUseXML = true\n\\nWantCheckpoint = false\n\\n"
-             "WantRemoteIO = true\n\\nWantRemoteSyscalls = false\n\\n"
-             "WhenToTransferOutput = \"ON_EXIT\"\n\\nx509userproxy = \""
-             "userproxy.pem\"\n\\nx509UserProxyEmail = \"argo-egi@cro-ngi.hr\""
-             "\n\\nx509UserProxyExpiration = 1705651369\n\\n"
-             "x509UserProxyFirstFQAN = \"/ops/Role=NULL/Capability=NULL\"\n\\n"
-             "x509UserProxyFQAN = \"/DC=EU/DC=EGI/C=HR/O=Robots/O=SRCE/CN="
-             "Robot:argo-egi@cro-ngi.hr,/ops/Role=NULL/Capability=NULL\"\n\\n"
-             "x509userproxysubject = \"/DC=EU/DC=EGI/C=HR/O=Robots/O=SRCE/CN="
-             "Robot:argo-egi@cro-ngi.hr\"\n\\nx509UserProxyVOName = "
-             "\"ops\"\n\\n\n\\n\\nCOMPLETED\\n\n = \"/etc/sensu/certs/"
-             "userproxy.pem\"\n\\nTargetType = \"Machine\"\n\\n"
-             "TotalSubmitProcs = 1\n\\nTotalSuspensions = 0\n\\n"
-             "TransferIn = false\n\\nTransferInputSizeMB = 0\n\\n"
-             "TransferOutputRemaps = undefined\n\\nUser = \"ops048@cern.ch\""
-             "\n\\nUserLog = \"gridjob.log\"\n\\nUserLogUseXML = true\n\\n"
-             "WantCheckpoint = false\n\\nWantRemoteIO = true\n\\n"
-             "WantRemoteSyscalls = false\n\\nWhenToTransferOutput = "
-             "\"ON_EXIT\"\n\\nx509userproxy = \"userproxy.pem\"\n\\n"
-             "x509UserProxyEmail = \"argo-egi@cro-ngi.hr\"\n\\n"
-             "x509UserProxyExpiration = 1705968173\n\\nx509UserProxyFirstFQAN ="
-             " \"/ops/Role=NULL/Capability=NULL\"\n\\nx509UserProxyFQAN = "
-             "\"/DC=EU/DC=EGI/C=HR/O=Robots/O=SRCE/CN=Robot:argo-egi@cro-ngi.hr"
-             ",/ops/Role=NULL/Capability=NULL\"\n\\nx509userproxysubject = \""
-             "/DC=EU/DC=EGI/C=HR/O=Robots/O=SRCE/CN=Robot:argo-egi@cro-ngi.hr\""
-             "\n\\nx509UserProxyVOName = \"ops\"\n\\n\n\\n\\nCOMPLETED\\n")
+        sample_output_multiline_with_breaks["check"]["output"] = (
+            "OK - Job successfully completed\\n=== ETF job log:\\nTimeout "
+            "limits configured were:\\n=== Credentials:\\nx509:\\n/DC=EU/DC="
+            "EGI/C=HR/O=Robots/O=SRCE/CN=Robot:argo-egi@cro-ngi.hr/CN="
+            "605601970\n\\n/ops/Role=NULL/Capability=NULL\n\\n\\n=== Job "
+            "description:\\nJDL([('universe', 'vanilla'), ('executable', "
+            "'hostname'), ('transfer_executable', 'true'), ('output', "
+            "'/var/lib/gridprobes/ops/scondor/alict-ce-01.ct.infn.it/out/"
+            "gridjob.out'), ('error', '/var/lib/gridprobes/ops/scondor/"
+            "alict-ce-01.ct.infn.it/out/gridjob.err'), ('log', '/var/lib/"
+            "gridprobes/ops/scondor/alict-ce-01.ct.infn.it/out/gridjob.log'), "
+            "('log_xml', 'true'), ('should_transfer_files', 'YES'), "
+            "('when_to_transfer_output', 'ON_EXIT'), ('use_x509userproxy', "
+            "'true')])\\n=== Job submission command:\\ncondor_submit --spool "
+            "--name alict-ce-01.ct.infn.it --pool alict-ce-01.ct.infn.it:9619 "
+            "/var/lib/gridprobes/ops/scondor/alict-ce-01.ct.infn.it/"
+            "gridjob.jdl\\nSubmitting job(s).\n\\n1 job(s) submitted to "
+            'cluster 1538415.\n\\n\\n=== Job log:\\nArguments = ""\n\\n'
+            "BytesRecvd = 15784.0\n\\nBytesSent = 24.0\n\\nClusterId = "
+            '1538415\n\\nCmd = "hostname"\n\\nCommittedSlotTime = 0\n\\n'
+            "CommittedSuspensionTime = 0\n\\nCommittedTime = 0\n\\n"
+            "CompletionDate = 1705930181\n\\nCondorPlatform = "
+            '"$CondorPlatform: x86_64_CentOS7 $"\n\\nCondorVersion = '
+            '"$CondorVersion: 9.0.20 Nov 15 2023 BuildID: 690225 PackageID: '
+            '9.0.20-1 $"\n\\nCoreSize = 0\n\\nCumulativeRemoteSysCpu = 0.0'
+            "\n\\nCumulativeRemoteUserCpu = 0.0\n\\nCumulativeSlotTime = 0"
+            "\n\\nCumulativeSuspensionTime = 0\n\\nCurrentHosts = 0\n\\n"
+            "DiskUsage = 40\n\\nDiskUsage_RAW = 40\n\\n"
+            "EncryptExecuteDirectory = false\n\\nEnteredCurrentStatus = "
+            '1705608983\n\\nEnvironment = ""\n\\nErr = "_condor_stderr"'
+            "\n\\nExecutableSize = 17\n\\nExecutableSize_RAW = 16\n\\n"
+            "ExitBySignal = false\n\\nExitCode = 0\n\\nExitStatus = 0\n\\n"
+            'GlobalJobId = "alict-ce-01.ct.infn.it#1538415.0#1705608982"'
+            "\n\\nHoldReason = undefined\n\\nHoldReasonCode = undefined\n\\n"
+            'ImageSize = 17\n\\nImageSize_RAW = 16\n\\nIn = "/dev/null"'
+            '\n\\nIwd = "/var/lib/condor-ce/spool/8415/0/cluster1538415.'
+            'proc0.subproc0"\n\\nJobCurrentStartDate = 1705930179\n\\n'
+            "JobCurrentStartExecutingDate = 1705930180\n\\n"
+            "JobFinishedHookDone = 1705930203\n\\nJobLeaseDuration = 2400"
+            "\n\\nJobNotification = 0\n\\nJobPrio = 0\n\\nJobRunCount = 1"
+            "\n\\nJobStartDate = 1705930179\n\\nJobStatus = 4\n\\n"
+            'JobUniverse = 5\n\\nLastHoldReason = "Spooling input data '
+            'files"\n\\nLastHoldReasonCode = 16\n\\nLastJobStatus = 1\n\\n'
+            "LastSuspensionTime = 0\n\\nLeaveJobInQueue = JobStatus == 4 && "
+            "(CompletionDate =?= undefined \\u2758\\u2758 CompletionDate == 0 "
+            "\\u2758\\u2758 ((time() - CompletionDate) < 864000))\n\\n"
+            'Managed = "ScheddDone"\n\\nManagedManager = ""\n\\n'
+            "MaxHosts = 1\n\\nMemoryUsage = ((ResidentSetSize + 1023) / "
+            '1024)\n\\nMinHosts = 1\n\\nMyType = "Job"\n\\nNumCkpts = 0'
+            "\n\\nNumCkpts_RAW = 0\n\\nNumJobCompletions = 0\n\\n"
+            "NumJobMatches = 1\n\\nNumJobStarts = 1\n\\nNumRestarts = 0\n\\n"
+            "NumShadowStarts = 1\n\\nNumSystemHolds = 0\n\\nOnExitHold = false"
+            '\n\\nOnExitRemove = true\n\\nOut = "_condor_stdout"\n\\n'
+            'Owner = "ops008"\n\\nPeriodicHold = false\n\\nPeriodicRelease ='
+            " false\n\\nPeriodicRemove = false\n\\nProcId = 0\n\\nQDate = "
+            '1705608981\n\\nRank = 0.0\n\\nReleaseReason = "Data files '
+            'spooled"\n\\nRemoteSysCpu = 0.0\n\\nRemoteUserCpu = 0.0\n\\n'
+            "RemoteWallClockTime = 2.0\n\\nRequestCpus = 1\n\\nRequestDisk = "
+            "DiskUsage\n\\nRequestMemory = ifthenelse(MemoryUsage =!= "
+            "undefined,MemoryUsage,(ImageSize + 1023) / 1024)\n\\n"
+            'Requirements = (TARGET.Arch == "X86_64") && (TARGET.OpSys == '
+            '"LINUX") && (TARGET.Disk >= RequestDisk) && (TARGET.Memory >= '
+            "RequestMemory) && (TARGET.HasFileTransfer)\n\\nResidentSetSize "
+            '= 0\n\\nResidentSetSize_RAW = 0\n\\nRootDir = "/"\n\\n'
+            'RoutedToJobId = "1537363.0"\n\\nScratchDirFileCount = 10\n\\n'
+            'ServerTime = 1705932987\n\\nShouldTransferFiles = "YES"\n\\n'
+            'SpooledOutputFiles = ""\n\\nStageInFinish = 1705608982\n\\n'
+            "StageInStart = 1705608982\n\\nStreamErr = false\n\\nStreamOut = "
+            'false\n\\nSUBMIT_Cmd = "/var/lib/gridprobes/ops/scondor/'
+            'alict-ce-01.ct.infn.it/hostname"\n\\nSUBMIT_Iwd = "/var/lib/'
+            'gridprobes/ops/scondor/alict-ce-01.ct.infn.it"\n\\nSUBMIT_'
+            'TransferOutputRemaps = "_condor_stdout=/var/lib/gridprobes/ops/'
+            "scondor/alict-ce-01.ct.infn.it/out/gridjob.out;_condor_stderr=/"
+            "var/lib/gridprobes/ops/scondor/alict-ce-01.ct.infn.it/out/"
+            'gridjob.err"\n\\nSUBMIT_UserLog = "/var/lib/gridprobes/ops/'
+            'scondor/alict-ce-01.ct.infn.it/out/gridjob.log"\n\\nSUBMIT_'
+            'x509userproxy = "/etc/sensu/certs/userproxy.pem"\n\\n'
+            'TargetType = "Machine"\n\\nTotalSubmitProcs = 1\n\\n'
+            "TotalSuspensions = 0\n\\nTransferIn = false\n\\n"
+            "TransferInputSizeMB = 0\n\\nTransferOutputRemaps = undefined"
+            '\n\\nUser = "ops008@T2HTC"\n\\nUserLog = "gridjob.log"\n\\n'
+            "UserLogUseXML = true\n\\nWantCheckpoint = false\n\\n"
+            "WantRemoteIO = true\n\\nWantRemoteSyscalls = false\n\\n"
+            'WhenToTransferOutput = "ON_EXIT"\n\\nx509userproxy = '
+            '"userproxy.pem"\n\\nx509UserProxyEmail = "argo-egi@cro-ngi.hr'
+            '"\n\\nx509UserProxyExpiration = 1705651369\n\\n'
+            'x509UserProxyFirstFQAN = "/ops/Role=NULL/Capability=NULL"\n\\n'
+            'x509UserProxyFQAN = "/DC=EU/DC=EGI/C=HR/O=Robots/O=SRCE/CN='
+            'Robot:argo-egi@cro-ngi.hr,/ops/Role=NULL/Capability=NULL"\n\\n'
+            'x509userproxysubject = "/DC=EU/DC=EGI/C=HR/O=Robots/O=SRCE/CN='
+            'Robot:argo-egi@cro-ngi.hr"\n\\nx509UserProxyVOName = "ops"'
+            '\n\\n\n\\n\\n=== Last job status:\\nArguments = ""\n\\n'
+            "BytesRecvd = 15784.0\n\\nBytesSent = 24.0\n\\nClusterId = 1538415"
+            '\n\\nCmd = "hostname"\n\\nCommittedSlotTime = 0\n\\n'
+            "CommittedSuspensionTime = 0\n\\nCommittedTime = 0\n\\n"
+            "CompletionDate = 1705930181\n\\nCondorPlatform = "
+            '"$CondorPlatform: x86_64_CentOS7 $"\n\\nCondorVersion = '
+            '"$CondorVersion: 9.0.20 Nov 15 2023 BuildID: 690225 PackageID: '
+            '9.0.20-1 $"\n\\nCoreSize = 0\n\\nCumulativeRemoteSysCpu = 0.0'
+            "\n\\nCumulativeRemoteUserCpu = 0.0\n\\nCumulativeSlotTime = 0"
+            "\n\\nCumulativeSuspensionTime = 0\n\\nCurrentHosts = 0\n\\n"
+            "DiskUsage = 40\n\\nDiskUsage_RAW = 40\n\\n"
+            "EncryptExecuteDirectory = false\n\\nEnteredCurrentStatus = "
+            '1705608983\n\\nEnvironment = ""\n\\nErr = "_condor_stderr'
+            '"\n\\nExecutableSize = 17\n\\nExecutableSize_RAW = 16\n\\n'
+            "ExitBySignal = false\n\\nExitCode = 0\n\\nExitStatus = 0\n\\n"
+            'GlobalJobId = "alict-ce-01.ct.infn.it#1538415.0#1705608982'
+            '"\n\\nHoldReason = undefined\n\\nHoldReasonCode = undefined'
+            '\n\\nImageSize = 17\n\\nImageSize_RAW = 16\n\\nIn = "/dev/null'
+            '"\n\\nIwd = "/var/lib/condor-ce/spool/8415/0/cluster1538415.'
+            'proc0.subproc0"\n\\nJobCurrentStartDate = 1705930179\n\\n'
+            "JobCurrentStartExecutingDate = 1705930180\n\\n"
+            "JobFinishedHookDone = 1705930203\n\\nJobLeaseDuration = 2400\n\\n"
+            "JobNotification = 0\n\\nJobPrio = 0\n\\nJobRunCount = 1\n\\n"
+            "JobStartDate = 1705930179\n\\nJobStatus = 4\n\\nJobUniverse = 5"
+            '\n\\nLastHoldReason = "Spooling input data files"\n\\n'
+            "LastHoldReasonCode = 16\n\\nLastJobStatus = 1\n\\n"
+            "LastSuspensionTime = 0\n\\nLeaveJobInQueue = JobStatus == 4 && "
+            "(CompletionDate =?= undefined \\u2758\\u2758 CompletionDate == 0"
+            " \\u2758\\u2758 ((time() - CompletionDate) < 864000))\n\\n"
+            'Managed = "ScheddDone"\n\\nManagedManager = ""\n\\n'
+            "MaxHosts = 1\n\\nMemoryUsage = ((ResidentSetSize + 1023) / 1024)"
+            '\n\\nMinHosts = 1\n\\nMyType = "Job"\n\\nNumCkpts = 0\n\\n'
+            "NumCkpts_RAW = 0\n\\nNumJobCompletions = 0\n\\nNumJobMatches = 1"
+            "\n\\nNumJobStarts = 1\n\\nNumRestarts = 0\n\\nNumShadowStarts = 1"
+            "\n\\nNumSystemHolds = 0\n\\nOnExitHold = false\n\\nOnExitRemove "
+            '= true\n\\nOut = "_condor_stdout"\n\\nOwner = "ops008"\n\\n'
+            "PeriodicHold = false\n\\nPeriodicRelease = false\n\\n"
+            "PeriodicRemove = false\n\\nProcId = 0\n\\nQDate = 1705608981\n\\n"
+            'Rank = 0.0\n\\nReleaseReason = "Data files spooled"\n\\n'
+            "RemoteSysCpu = 0.0\n\\nRemoteUserCpu = 0.0\n\\n"
+            "RemoteWallClockTime = 2.0\n\\nRequestCpus = 1\n\\nRequestDisk = "
+            "DiskUsage\n\\nRequestMemory = ifthenelse(MemoryUsage =!= "
+            "undefined,MemoryUsage,(ImageSize + 1023) / 1024)\n\\n"
+            'Requirements = (TARGET.Arch == "X86_64") && (TARGET.OpSys == '
+            '"LINUX") && (TARGET.Disk >= RequestDisk) && (TARGET.Memory >= '
+            "RequestMemory) && (TARGET.HasFileTransfer)\n\\nResidentSetSize "
+            '= 0\n\\nResidentSetSize_RAW = 0\n\\nRootDir = "/"\n\\n'
+            'RoutedToJobId = "1537363.0"\n\\nScratchDirFileCount = 10\n\\n'
+            'ServerTime = 1705932985\n\\nShouldTransferFiles = "YES"\n\\n'
+            'SpooledOutputFiles = ""\n\\nStageInFinish = 1705608982\n\\n'
+            "StageInStart = 1705608982\n\\nStreamErr = false\n\\nStreamOut = "
+            'false\n\\nSUBMIT_Cmd = "/var/lib/gridprobes/ops/scondor/'
+            'alict-ce-01.ct.infn.it/hostname"\n\\nSUBMIT_Iwd = "/var/lib/'
+            'gridprobes/ops/scondor/alict-ce-01.ct.infn.it"\n\\nSUBMIT_'
+            'TransferOutputRemaps = "_condor_stdout=/var/lib/gridprobes/ops/'
+            "scondor/alict-ce-01.ct.infn.it/out/gridjob.out;_condor_stderr="
+            "/var/lib/gridprobes/ops/scondor/alict-ce-01.ct.infn.it/out/"
+            'gridjob.err"\n\\nSUBMIT_UserLog = "/var/lib/gridprobes/ops/'
+            'scondor/alict-ce-01.ct.infn.it/out/gridjob.log"\n\\nSUBMIT_'
+            'x509userproxy = "/etc/sensu/certs/userproxy.pem"\n\\n'
+            'TargetType = "Machine"\n\\nTotalSubmitProcs = 1\n\\n'
+            "TotalSuspensions = 0\n\\nTransferIn = false\n\\n"
+            "TransferInputSizeMB = 0\n\\nTransferOutputRemaps = undefined\n\\n"
+            'User = "ops008@T2HTC"\n\\nUserLog = "gridjob.log"\n\\n'
+            "UserLogUseXML = true\n\\nWantCheckpoint = false\n\\n"
+            "WantRemoteIO = true\n\\nWantRemoteSyscalls = false\n\\n"
+            'WhenToTransferOutput = "ON_EXIT"\n\\nx509userproxy = "'
+            'userproxy.pem"\n\\nx509UserProxyEmail = "argo-egi@cro-ngi.hr"'
+            "\n\\nx509UserProxyExpiration = 1705651369\n\\n"
+            'x509UserProxyFirstFQAN = "/ops/Role=NULL/Capability=NULL"\n\\n'
+            'x509UserProxyFQAN = "/DC=EU/DC=EGI/C=HR/O=Robots/O=SRCE/CN='
+            'Robot:argo-egi@cro-ngi.hr,/ops/Role=NULL/Capability=NULL"\n\\n'
+            'x509userproxysubject = "/DC=EU/DC=EGI/C=HR/O=Robots/O=SRCE/CN='
+            'Robot:argo-egi@cro-ngi.hr"\n\\nx509UserProxyVOName = '
+            '"ops"\n\\n\n\\n\\nCOMPLETED\\n\n = "/etc/sensu/certs/'
+            'userproxy.pem"\n\\nTargetType = "Machine"\n\\n'
+            "TotalSubmitProcs = 1\n\\nTotalSuspensions = 0\n\\n"
+            "TransferIn = false\n\\nTransferInputSizeMB = 0\n\\n"
+            'TransferOutputRemaps = undefined\n\\nUser = "ops048@cern.ch"'
+            '\n\\nUserLog = "gridjob.log"\n\\nUserLogUseXML = true\n\\n'
+            "WantCheckpoint = false\n\\nWantRemoteIO = true\n\\n"
+            "WantRemoteSyscalls = false\n\\nWhenToTransferOutput = "
+            '"ON_EXIT"\n\\nx509userproxy = "userproxy.pem"\n\\n'
+            'x509UserProxyEmail = "argo-egi@cro-ngi.hr"\n\\n'
+            "x509UserProxyExpiration = 1705968173\n\\nx509UserProxyFirstFQAN ="
+            ' "/ops/Role=NULL/Capability=NULL"\n\\nx509UserProxyFQAN = '
+            '"/DC=EU/DC=EGI/C=HR/O=Robots/O=SRCE/CN=Robot:argo-egi@cro-ngi.hr'
+            ',/ops/Role=NULL/Capability=NULL"\n\\nx509userproxysubject = "'
+            '/DC=EU/DC=EGI/C=HR/O=Robots/O=SRCE/CN=Robot:argo-egi@cro-ngi.hr"'
+            '\n\\nx509UserProxyVOName = "ops"\n\\n\n\\n\\nCOMPLETED\\n'
+        )
         sample_output_multi_tenant_check = copy.deepcopy(sample_output)
-        sample_output_multi_tenant_check["check"]["metadata"]["labels"][
-            "tenants"
-        ] = "TENANT,TENANT2"
+        sample_output_multi_tenant_check["check"]["metadata"]["labels"]["tenants"] = (
+            "TENANT,TENANT2"
+        )
         sample_output_multi_tenant_check_entity = copy.deepcopy(sample_output)
-        sample_output_multi_tenant_check_entity["check"]["metadata"]["labels"][
-            "tenants"
-        ] = "TENANT1,TENANT2"
-        sample_output_multi_tenant_check_entity["entity"]["metadata"]["labels"][
-            "tenants"
-        ] = "TENANT1, TENANT2, TENANT3"
+        sample_output_multi_tenant_check_entity["check"]["metadata"]["labels"]["tenants"] = (
+            "TENANT1,TENANT2"
+        )
+        sample_output_multi_tenant_check_entity["entity"]["metadata"]["labels"]["tenants"] = (
+            "TENANT1, TENANT2, TENANT3"
+        )
         self.output = MetricOutput(data=sample_output)
         self.output_oneline = MetricOutput(data=sample_output_one_line)
-        self.output_oneline_perfdata = MetricOutput(
-            data=sample_output_one_line_with_perfdata
-        )
-        self.output_multiline_no_perfdata = MetricOutput(
-            data=sample_output_multiline_no_perfdata
-        )
-        self.output_multiline_with_breaks = MetricOutput(
-            data=sample_output_multiline_with_breaks
-        )
-        self.output_multitenant_check = MetricOutput(
-            data=sample_output_multi_tenant_check
-        )
+        self.output_oneline_perfdata = MetricOutput(data=sample_output_one_line_with_perfdata)
+        self.output_multiline_no_perfdata = MetricOutput(data=sample_output_multiline_no_perfdata)
+        self.output_multiline_with_breaks = MetricOutput(data=sample_output_multiline_with_breaks)
+        self.output_multitenant_check = MetricOutput(data=sample_output_multi_tenant_check)
         self.output_multitenant_check_entity = MetricOutput(
             data=sample_output_multi_tenant_check_entity
         )
 
     def test_get_service(self):
-        self.assertEqual(
-            self.output.get_service(), "eu.eosc.portal.services.url"
-        )
+        self.assertEqual(self.output.get_service(), "eu.eosc.portal.services.url")
 
     def test_get_hostname(self):
-        self.assertEqual(
-            self.output.get_hostname(), "hostname.example.eu_site-name"
-        )
+        self.assertEqual(self.output.get_hostname(), "hostname.example.eu_site-name")
 
     def test_get_metric_name(self):
         self.assertEqual(self.output.get_metric_name(), "generic.http.connect")
@@ -9224,16 +7499,13 @@ class MetricOutputTests(unittest.TestCase):
 
     def test_get_message(self):
         self.assertEqual(
-            self.output.get_message(),
-            "LONG TEXT LINE 1\nLONG TEXT LINE 2\nLONG TEXT LINE 3"
+            self.output.get_message(), "LONG TEXT LINE 1\nLONG TEXT LINE 2\nLONG TEXT LINE 3"
         )
         self.assertEqual(self.output_oneline.get_message(), "")
-        self.assertEqual(
-            self.output_oneline_perfdata.get_message(), ""
-        )
+        self.assertEqual(self.output_oneline_perfdata.get_message(), "")
         self.assertEqual(
             self.output_multiline_no_perfdata.get_message(),
-            "LONG TEXT LINE 1\nLONG TEXT LINE 2\nLONG TEXT LINE 3"
+            "LONG TEXT LINE 1\nLONG TEXT LINE 2\nLONG TEXT LINE 3",
         )
         self.assertEqual(
             self.output_multiline_with_breaks.get_message(),
@@ -9252,185 +7524,177 @@ class MetricOutputTests(unittest.TestCase):
             "--name alict-ce-01.ct.infn.it --pool alict-ce-01.ct.infn.it:9619 "
             "/var/lib/gridprobes/ops/scondor/alict-ce-01.ct.infn.it/gridjob.jdl"
             "\nSubmitting job(s).\n\n1 job(s) submitted to cluster 1538415."
-            "\n\n\n=== Job log:\nArguments = \"\"\n\nBytesRecvd = 15784.0\n\n"
-            "BytesSent = 24.0\n\nClusterId = 1538415\n\nCmd = \"hostname\"\n\n"
+            '\n\n\n=== Job log:\nArguments = ""\n\nBytesRecvd = 15784.0\n\n'
+            'BytesSent = 24.0\n\nClusterId = 1538415\n\nCmd = "hostname"\n\n'
             "CommittedSlotTime = 0\n\nCommittedSuspensionTime = 0\n\n"
             "CommittedTime = 0\n\nCompletionDate = 1705930181\n\nCondorPlatform"
-            " = \"$CondorPlatform: x86_64_CentOS7 $\"\n\nCondorVersion = "
-            "\"$CondorVersion: 9.0.20 Nov 15 2023 BuildID: 690225 PackageID: "
-            "9.0.20-1 $\"\n\nCoreSize = 0\n\nCumulativeRemoteSysCpu = 0.0\n\n"
+            ' = "$CondorPlatform: x86_64_CentOS7 $"\n\nCondorVersion = '
+            '"$CondorVersion: 9.0.20 Nov 15 2023 BuildID: 690225 PackageID: '
+            '9.0.20-1 $"\n\nCoreSize = 0\n\nCumulativeRemoteSysCpu = 0.0\n\n'
             "CumulativeRemoteUserCpu = 0.0\n\nCumulativeSlotTime = 0\n\n"
             "CumulativeSuspensionTime = 0\n\nCurrentHosts = 0\n\nDiskUsage = 40"
             "\n\nDiskUsage_RAW = 40\n\nEncryptExecuteDirectory = false\n\n"
-            "EnteredCurrentStatus = 1705608983\n\nEnvironment = \"\"\n\n"
-            "Err = \"_condor_stderr\"\n\nExecutableSize = 17\n\n"
+            'EnteredCurrentStatus = 1705608983\n\nEnvironment = ""\n\n'
+            'Err = "_condor_stderr"\n\nExecutableSize = 17\n\n'
             "ExecutableSize_RAW = 16\n\nExitBySignal = false\n\nExitCode = 0"
-            "\n\nExitStatus = 0\n\nGlobalJobId = \"alict-ce-01.ct.infn.it#"
-            "1538415.0#1705608982\"\n\nHoldReason = undefined\n\nHoldReasonCode"
+            '\n\nExitStatus = 0\n\nGlobalJobId = "alict-ce-01.ct.infn.it#'
+            '1538415.0#1705608982"\n\nHoldReason = undefined\n\nHoldReasonCode'
             " = undefined\n\nImageSize = 17\n\nImageSize_RAW = 16\n\nIn = "
-            "\"/dev/null\"\n\nIwd = \"/var/lib/condor-ce/spool/8415/0/"
-            "cluster1538415.proc0.subproc0\"\n\nJobCurrentStartDate = "
+            '"/dev/null"\n\nIwd = "/var/lib/condor-ce/spool/8415/0/'
+            'cluster1538415.proc0.subproc0"\n\nJobCurrentStartDate = '
             "1705930179\n\nJobCurrentStartExecutingDate = 1705930180\n\n"
             "JobFinishedHookDone = 1705930203\n\nJobLeaseDuration = 2400\n\n"
             "JobNotification = 0\n\nJobPrio = 0\n\nJobRunCount = 1\n\n"
             "JobStartDate = 1705930179\n\nJobStatus = 4\n\nJobUniverse = 5\n\n"
-            "LastHoldReason = \"Spooling input data files\"\n\n"
+            'LastHoldReason = "Spooling input data files"\n\n'
             "LastHoldReasonCode = 16\n\nLastJobStatus = 1\n\n"
             "LastSuspensionTime = 0\n\nLeaveJobInQueue = JobStatus == 4 && ("
             "CompletionDate =?= undefined \\u2758\\u2758 CompletionDate == 0 "
             "\\u2758\\u2758 ((time() - CompletionDate) < 864000))\n\nManaged = "
-            "\"ScheddDone\"\n\nManagedManager = \"\"\n\nMaxHosts = 1\n\n"
+            '"ScheddDone"\n\nManagedManager = ""\n\nMaxHosts = 1\n\n'
             "MemoryUsage = ((ResidentSetSize + 1023) / 1024)\n\nMinHosts = 1"
-            "\n\nMyType = \"Job\"\n\nNumCkpts = 0\n\nNumCkpts_RAW = 0\n\n"
+            '\n\nMyType = "Job"\n\nNumCkpts = 0\n\nNumCkpts_RAW = 0\n\n'
             "NumJobCompletions = 0\n\nNumJobMatches = 1\n\nNumJobStarts = 1\n\n"
             "NumRestarts = 0\n\nNumShadowStarts = 1\n\nNumSystemHolds = 0\n\n"
             "OnExitHold = false\n\nOnExitRemove = true\n\nOut = "
-            "\"_condor_stdout\"\n\nOwner = \"ops008\"\n\nPeriodicHold = false"
+            '"_condor_stdout"\n\nOwner = "ops008"\n\nPeriodicHold = false'
             "\n\nPeriodicRelease = false\n\nPeriodicRemove = false\n\nProcId ="
             " 0\n\nQDate = 1705608981\n\nRank = 0.0\n\nReleaseReason = "
-            "\"Data files spooled\"\n\nRemoteSysCpu = 0.0\n\nRemoteUserCpu = "
+            '"Data files spooled"\n\nRemoteSysCpu = 0.0\n\nRemoteUserCpu = '
             "0.0\n\nRemoteWallClockTime = 2.0\n\nRequestCpus = 1\n\nRequestDisk"
             " = DiskUsage\n\nRequestMemory = ifthenelse(MemoryUsage =!= "
             "undefined,MemoryUsage,(ImageSize + 1023) / 1024)\n\n"
-            "Requirements = (TARGET.Arch == \"X86_64\") && (TARGET.OpSys == "
-            "\"LINUX\") && (TARGET.Disk >= RequestDisk) && (TARGET.Memory >= "
+            'Requirements = (TARGET.Arch == "X86_64") && (TARGET.OpSys == '
+            '"LINUX") && (TARGET.Disk >= RequestDisk) && (TARGET.Memory >= '
             "RequestMemory) && (TARGET.HasFileTransfer)\n\nResidentSetSize = 0"
-            "\n\nResidentSetSize_RAW = 0\n\nRootDir = \"/\"\n\n"
-            "RoutedToJobId = \"1537363.0\"\n\nScratchDirFileCount = 10\n\n"
-            "ServerTime = 1705932987\n\nShouldTransferFiles = \"YES\"\n\n"
-            "SpooledOutputFiles = \"\"\n\nStageInFinish = 1705608982\n\n"
+            '\n\nResidentSetSize_RAW = 0\n\nRootDir = "/"\n\n'
+            'RoutedToJobId = "1537363.0"\n\nScratchDirFileCount = 10\n\n'
+            'ServerTime = 1705932987\n\nShouldTransferFiles = "YES"\n\n'
+            'SpooledOutputFiles = ""\n\nStageInFinish = 1705608982\n\n'
             "StageInStart = 1705608982\n\nStreamErr = false\n\nStreamOut = "
-            "false\n\nSUBMIT_Cmd = \"/var/lib/gridprobes/ops/scondor/"
-            "alict-ce-01.ct.infn.it/hostname\"\n\nSUBMIT_Iwd = \"/var/lib/"
-            "gridprobes/ops/scondor/alict-ce-01.ct.infn.it\"\n\n"
-            "SUBMIT_TransferOutputRemaps = \"_condor_stdout=/var/lib/"
+            'false\n\nSUBMIT_Cmd = "/var/lib/gridprobes/ops/scondor/'
+            'alict-ce-01.ct.infn.it/hostname"\n\nSUBMIT_Iwd = "/var/lib/'
+            'gridprobes/ops/scondor/alict-ce-01.ct.infn.it"\n\n'
+            'SUBMIT_TransferOutputRemaps = "_condor_stdout=/var/lib/'
             "gridprobes/ops/scondor/alict-ce-01.ct.infn.it/out/gridjob.out;"
             "_condor_stderr=/var/lib/gridprobes/ops/scondor/alict-ce-01.ct."
-            "infn.it/out/gridjob.err\"\n\nSUBMIT_UserLog = \"/var/lib/"
-            "gridprobes/ops/scondor/alict-ce-01.ct.infn.it/out/gridjob.log\""
-            "\n\nSUBMIT_x509userproxy = \"/etc/sensu/certs/userproxy.pem\"\n\n"
-            "TargetType = \"Machine\"\n\nTotalSubmitProcs = 1\n\n"
+            'infn.it/out/gridjob.err"\n\nSUBMIT_UserLog = "/var/lib/'
+            'gridprobes/ops/scondor/alict-ce-01.ct.infn.it/out/gridjob.log"'
+            '\n\nSUBMIT_x509userproxy = "/etc/sensu/certs/userproxy.pem"\n\n'
+            'TargetType = "Machine"\n\nTotalSubmitProcs = 1\n\n'
             "TotalSuspensions = 0\n\nTransferIn = false\n\nTransferInputSizeMB "
-            "= 0\n\nTransferOutputRemaps = undefined\n\nUser = \"ops008@T2HTC\""
-            "\n\nUserLog = \"gridjob.log\"\n\nUserLogUseXML = true\n\n"
+            '= 0\n\nTransferOutputRemaps = undefined\n\nUser = "ops008@T2HTC"'
+            '\n\nUserLog = "gridjob.log"\n\nUserLogUseXML = true\n\n'
             "WantCheckpoint = false\n\nWantRemoteIO = true\n\n"
-            "WantRemoteSyscalls = false\n\nWhenToTransferOutput = \"ON_EXIT\""
-            "\n\nx509userproxy = \"userproxy.pem\"\n\nx509UserProxyEmail = "
-            "\"argo-egi@cro-ngi.hr\"\n\nx509UserProxyExpiration = 1705651369"
-            "\n\nx509UserProxyFirstFQAN = \"/ops/Role=NULL/Capability=NULL\"\n"
-            "\nx509UserProxyFQAN = \"/DC=EU/DC=EGI/C=HR/O=Robots/O=SRCE/CN="
-            "Robot:argo-egi@cro-ngi.hr,/ops/Role=NULL/Capability=NULL\"\n\n"
-            "x509userproxysubject = \"/DC=EU/DC=EGI/C=HR/O=Robots/O=SRCE/CN="
-            "Robot:argo-egi@cro-ngi.hr\"\n\nx509UserProxyVOName = \"ops\""
-            "\n\n\n\n\n=== Last job status:\nArguments = \"\"\n\nBytesRecvd = "
+            'WantRemoteSyscalls = false\n\nWhenToTransferOutput = "ON_EXIT"'
+            '\n\nx509userproxy = "userproxy.pem"\n\nx509UserProxyEmail = '
+            '"argo-egi@cro-ngi.hr"\n\nx509UserProxyExpiration = 1705651369'
+            '\n\nx509UserProxyFirstFQAN = "/ops/Role=NULL/Capability=NULL"\n'
+            '\nx509UserProxyFQAN = "/DC=EU/DC=EGI/C=HR/O=Robots/O=SRCE/CN='
+            'Robot:argo-egi@cro-ngi.hr,/ops/Role=NULL/Capability=NULL"\n\n'
+            'x509userproxysubject = "/DC=EU/DC=EGI/C=HR/O=Robots/O=SRCE/CN='
+            'Robot:argo-egi@cro-ngi.hr"\n\nx509UserProxyVOName = "ops"'
+            '\n\n\n\n\n=== Last job status:\nArguments = ""\n\nBytesRecvd = '
             "15784.0\n\nBytesSent = 24.0\n\nClusterId = 1538415\n\nCmd = "
-            "\"hostname\"\n\nCommittedSlotTime = 0\n\nCommittedSuspensionTime "
+            '"hostname"\n\nCommittedSlotTime = 0\n\nCommittedSuspensionTime '
             "= 0\n\nCommittedTime = 0\n\nCompletionDate = 1705930181\n\n"
-            "CondorPlatform = \"$CondorPlatform: x86_64_CentOS7 $\"\n\n"
-            "CondorVersion = \"$CondorVersion: 9.0.20 Nov 15 2023 BuildID: "
-            "690225 PackageID: 9.0.20-1 $\"\n\nCoreSize = 0\n\n"
+            'CondorPlatform = "$CondorPlatform: x86_64_CentOS7 $"\n\n'
+            'CondorVersion = "$CondorVersion: 9.0.20 Nov 15 2023 BuildID: '
+            '690225 PackageID: 9.0.20-1 $"\n\nCoreSize = 0\n\n'
             "CumulativeRemoteSysCpu = 0.0\n\nCumulativeRemoteUserCpu = 0.0\n\n"
             "CumulativeSlotTime = 0\n\nCumulativeSuspensionTime = 0\n\n"
             "CurrentHosts = 0\n\nDiskUsage = 40\n\nDiskUsage_RAW = 40\n\n"
             "EncryptExecuteDirectory = false\n\nEnteredCurrentStatus = "
-            "1705608983\n\nEnvironment = \"\"\n\nErr = \"_condor_stderr\"\n\n"
+            '1705608983\n\nEnvironment = ""\n\nErr = "_condor_stderr"\n\n'
             "ExecutableSize = 17\n\nExecutableSize_RAW = 16\n\nExitBySignal = "
             "false\n\nExitCode = 0\n\nExitStatus = 0\n\nGlobalJobId = "
-            "\"alict-ce-01.ct.infn.it#1538415.0#1705608982\"\n\nHoldReason = "
+            '"alict-ce-01.ct.infn.it#1538415.0#1705608982"\n\nHoldReason = '
             "undefined\n\nHoldReasonCode = undefined\n\nImageSize = 17\n\n"
-            "ImageSize_RAW = 16\n\nIn = \"/dev/null\"\n\nIwd = \"/var/lib/"
-            "condor-ce/spool/8415/0/cluster1538415.proc0.subproc0\"\n\n"
+            'ImageSize_RAW = 16\n\nIn = "/dev/null"\n\nIwd = "/var/lib/'
+            'condor-ce/spool/8415/0/cluster1538415.proc0.subproc0"\n\n'
             "JobCurrentStartDate = 1705930179\n\nJobCurrentStartExecutingDate "
             "= 1705930180\n\nJobFinishedHookDone = 1705930203\n\n"
             "JobLeaseDuration = 2400\n\nJobNotification = 0\n\nJobPrio = 0"
             "\n\nJobRunCount = 1\n\nJobStartDate = 1705930179\n\nJobStatus = 4"
-            "\n\nJobUniverse = 5\n\nLastHoldReason = \"Spooling input data "
-            "files\"\n\nLastHoldReasonCode = 16\n\nLastJobStatus = 1\n\n"
+            '\n\nJobUniverse = 5\n\nLastHoldReason = "Spooling input data '
+            'files"\n\nLastHoldReasonCode = 16\n\nLastJobStatus = 1\n\n'
             "LastSuspensionTime = 0\n\nLeaveJobInQueue = JobStatus == 4 && "
             "(CompletionDate =?= undefined \\u2758\\u2758 CompletionDate == 0 "
             "\\u2758\\u2758 ((time() - CompletionDate) < 864000))\n\nManaged = "
-            "\"ScheddDone\"\n\nManagedManager = \"\"\n\nMaxHosts = 1\n\n"
+            '"ScheddDone"\n\nManagedManager = ""\n\nMaxHosts = 1\n\n'
             "MemoryUsage = ((ResidentSetSize + 1023) / 1024)\n\nMinHosts = 1"
-            "\n\nMyType = \"Job\"\n\nNumCkpts = 0\n\nNumCkpts_RAW = 0\n\n"
+            '\n\nMyType = "Job"\n\nNumCkpts = 0\n\nNumCkpts_RAW = 0\n\n'
             "NumJobCompletions = 0\n\nNumJobMatches = 1\n\nNumJobStarts = 1"
             "\n\nNumRestarts = 0\n\nNumShadowStarts = 1\n\nNumSystemHolds = 0"
             "\n\nOnExitHold = false\n\nOnExitRemove = true\n\nOut = "
-            "\"_condor_stdout\"\n\nOwner = \"ops008\"\n\nPeriodicHold = false"
+            '"_condor_stdout"\n\nOwner = "ops008"\n\nPeriodicHold = false'
             "\n\nPeriodicRelease = false\n\nPeriodicRemove = false\n\nProcId "
             "= 0\n\nQDate = 1705608981\n\nRank = 0.0\n\nReleaseReason = "
-            "\"Data files spooled\"\n\nRemoteSysCpu = 0.0\n\nRemoteUserCpu = "
+            '"Data files spooled"\n\nRemoteSysCpu = 0.0\n\nRemoteUserCpu = '
             "0.0\n\nRemoteWallClockTime = 2.0\n\nRequestCpus = 1\n\n"
             "RequestDisk = DiskUsage\n\nRequestMemory = ifthenelse(MemoryUsage "
             "=!= undefined,MemoryUsage,(ImageSize + 1023) / 1024)\n\n"
-            "Requirements = (TARGET.Arch == \"X86_64\") && (TARGET.OpSys == "
-            "\"LINUX\") && (TARGET.Disk >= RequestDisk) && (TARGET.Memory >= "
+            'Requirements = (TARGET.Arch == "X86_64") && (TARGET.OpSys == '
+            '"LINUX") && (TARGET.Disk >= RequestDisk) && (TARGET.Memory >= '
             "RequestMemory) && (TARGET.HasFileTransfer)\n\nResidentSetSize = 0"
-            "\n\nResidentSetSize_RAW = 0\n\nRootDir = \"/\"\n\nRoutedToJobId = "
-            "\"1537363.0\"\n\nScratchDirFileCount = 10\n\nServerTime = "
-            "1705932985\n\nShouldTransferFiles = \"YES\"\n\nSpooledOutputFiles "
-            "= \"\"\n\nStageInFinish = 1705608982\n\nStageInStart = 1705608982"
+            '\n\nResidentSetSize_RAW = 0\n\nRootDir = "/"\n\nRoutedToJobId = '
+            '"1537363.0"\n\nScratchDirFileCount = 10\n\nServerTime = '
+            '1705932985\n\nShouldTransferFiles = "YES"\n\nSpooledOutputFiles '
+            '= ""\n\nStageInFinish = 1705608982\n\nStageInStart = 1705608982'
             "\n\nStreamErr = false\n\nStreamOut = false\n\nSUBMIT_Cmd = "
-            "\"/var/lib/gridprobes/ops/scondor/alict-ce-01.ct.infn.it/hostname"
-            "\"\n\nSUBMIT_Iwd = \"/var/lib/gridprobes/ops/scondor/"
-            "alict-ce-01.ct.infn.it\"\n\nSUBMIT_TransferOutputRemaps = "
-            "\"_condor_stdout=/var/lib/gridprobes/ops/scondor/alict-ce-01.ct."
+            '"/var/lib/gridprobes/ops/scondor/alict-ce-01.ct.infn.it/hostname'
+            '"\n\nSUBMIT_Iwd = "/var/lib/gridprobes/ops/scondor/'
+            'alict-ce-01.ct.infn.it"\n\nSUBMIT_TransferOutputRemaps = '
+            '"_condor_stdout=/var/lib/gridprobes/ops/scondor/alict-ce-01.ct.'
             "infn.it/out/gridjob.out;_condor_stderr=/var/lib/gridprobes/ops/"
-            "scondor/alict-ce-01.ct.infn.it/out/gridjob.err\"\n\n"
-            "SUBMIT_UserLog = \"/var/lib/gridprobes/ops/scondor/alict-ce-01."
-            "ct.infn.it/out/gridjob.log\"\n\nSUBMIT_x509userproxy = \"/etc/"
-            "sensu/certs/userproxy.pem\"\n\nTargetType = \"Machine\"\n\n"
+            'scondor/alict-ce-01.ct.infn.it/out/gridjob.err"\n\n'
+            'SUBMIT_UserLog = "/var/lib/gridprobes/ops/scondor/alict-ce-01.'
+            'ct.infn.it/out/gridjob.log"\n\nSUBMIT_x509userproxy = "/etc/'
+            'sensu/certs/userproxy.pem"\n\nTargetType = "Machine"\n\n'
             "TotalSubmitProcs = 1\n\nTotalSuspensions = 0\n\nTransferIn = false"
             "\n\nTransferInputSizeMB = 0\n\nTransferOutputRemaps = undefined"
-            "\n\nUser = \"ops008@T2HTC\"\n\nUserLog = \"gridjob.log\"\n\n"
+            '\n\nUser = "ops008@T2HTC"\n\nUserLog = "gridjob.log"\n\n'
             "UserLogUseXML = true\n\nWantCheckpoint = false\n\nWantRemoteIO = "
             "true\n\nWantRemoteSyscalls = false\n\nWhenToTransferOutput = "
-            "\"ON_EXIT\"\n\nx509userproxy = \"userproxy.pem\"\n\n"
-            "x509UserProxyEmail = \"argo-egi@cro-ngi.hr\"\n\n"
+            '"ON_EXIT"\n\nx509userproxy = "userproxy.pem"\n\n'
+            'x509UserProxyEmail = "argo-egi@cro-ngi.hr"\n\n'
             "x509UserProxyExpiration = 1705651369\n\nx509UserProxyFirstFQAN = "
-            "\"/ops/Role=NULL/Capability=NULL\"\n\nx509UserProxyFQAN = \"/DC=EU"
+            '"/ops/Role=NULL/Capability=NULL"\n\nx509UserProxyFQAN = "/DC=EU'
             "/DC=EGI/C=HR/O=Robots/O=SRCE/CN=Robot:argo-egi@cro-ngi.hr,/ops/"
-            "Role=NULL/Capability=NULL\"\n\nx509userproxysubject = \"/DC=EU/DC="
-            "EGI/C=HR/O=Robots/O=SRCE/CN=Robot:argo-egi@cro-ngi.hr\"\n\n"
-            "x509UserProxyVOName = \"ops\"\n\n\n\n\nCOMPLETED\n\n = \"/etc/"
-            "sensu/certs/userproxy.pem\"\n\nTargetType = \"Machine\"\n\n"
+            'Role=NULL/Capability=NULL"\n\nx509userproxysubject = "/DC=EU/DC='
+            'EGI/C=HR/O=Robots/O=SRCE/CN=Robot:argo-egi@cro-ngi.hr"\n\n'
+            'x509UserProxyVOName = "ops"\n\n\n\n\nCOMPLETED\n\n = "/etc/'
+            'sensu/certs/userproxy.pem"\n\nTargetType = "Machine"\n\n'
             "TotalSubmitProcs = 1\n\nTotalSuspensions = 0\n\nTransferIn = false"
             "\n\nTransferInputSizeMB = 0\n\nTransferOutputRemaps = undefined"
-            "\n\nUser = \"ops048@cern.ch\"\n\nUserLog = \"gridjob.log\"\n\n"
+            '\n\nUser = "ops048@cern.ch"\n\nUserLog = "gridjob.log"\n\n'
             "UserLogUseXML = true\n\nWantCheckpoint = false\n\nWantRemoteIO = "
             "true\n\nWantRemoteSyscalls = false\n\nWhenToTransferOutput = "
-            "\"ON_EXIT\"\n\nx509userproxy = \"userproxy.pem\"\n\n"
-            "x509UserProxyEmail = \"argo-egi@cro-ngi.hr\"\n\n"
+            '"ON_EXIT"\n\nx509userproxy = "userproxy.pem"\n\n'
+            'x509UserProxyEmail = "argo-egi@cro-ngi.hr"\n\n'
             "x509UserProxyExpiration = 1705968173\n\nx509UserProxyFirstFQAN = "
-            "\"/ops/Role=NULL/Capability=NULL\"\n\nx509UserProxyFQAN = \"/DC=EU"
+            '"/ops/Role=NULL/Capability=NULL"\n\nx509UserProxyFQAN = "/DC=EU'
             "/DC=EGI/C=HR/O=Robots/O=SRCE/CN=Robot:argo-egi@cro-ngi.hr,/ops/"
-            "Role=NULL/Capability=NULL\"\n\nx509userproxysubject = \"/DC=EU/"
-            "DC=EGI/C=HR/O=Robots/O=SRCE/CN=Robot:argo-egi@cro-ngi.hr\"\n\n"
-            "x509UserProxyVOName = \"ops\"\n\n\n\n\nCOMPLETED"
+            'Role=NULL/Capability=NULL"\n\nx509userproxysubject = "/DC=EU/'
+            'DC=EGI/C=HR/O=Robots/O=SRCE/CN=Robot:argo-egi@cro-ngi.hr"\n\n'
+            'x509UserProxyVOName = "ops"\n\n\n\n\nCOMPLETED',
         )
 
     def test_get_summary(self):
         self.assertEqual(self.output.get_summary(), "TEXT OUTPUT")
         self.assertEqual(self.output_oneline.get_summary(), "TEXT OUTPUT")
+        self.assertEqual(self.output_oneline_perfdata.get_summary(), "TEXT OUTPUT")
+        self.assertEqual(self.output_multiline_no_perfdata.get_summary(), "TEXT OUTPUT")
         self.assertEqual(
-            self.output_oneline_perfdata.get_summary(), "TEXT OUTPUT"
-        )
-        self.assertEqual(
-            self.output_multiline_no_perfdata.get_summary(), "TEXT OUTPUT"
-        )
-        self.assertEqual(
-            self.output_multiline_with_breaks.get_summary(),
-            "OK - Job successfully completed"
+            self.output_multiline_with_breaks.get_summary(), "OK - Job successfully completed"
         )
 
     def test_get_perfdata(self):
         self.assertEqual(
-            self.output.get_perfdata(),
-            "OPTIONAL PERFDATA PERFDATA LINE 2 PERFDATA LINE 3"
+            self.output.get_perfdata(), "OPTIONAL PERFDATA PERFDATA LINE 2 PERFDATA LINE 3"
         )
         self.assertEqual(self.output_oneline.get_perfdata(), "")
-        self.assertEqual(
-            self.output_oneline_perfdata.get_perfdata(), "OPTIONAL PERFDATA"
-        )
+        self.assertEqual(self.output_oneline_perfdata.get_perfdata(), "OPTIONAL PERFDATA")
         self.assertEqual(self.output_multiline_no_perfdata.get_perfdata(), "")
 
     def test_get_site(self):
@@ -9441,13 +7705,8 @@ class MetricOutputTests(unittest.TestCase):
 
     def test_get_tenants(self):
         self.assertEqual(self.output.get_tenants(), ["TENANT"])
-        self.assertEqual(
-            self.output_multitenant_check.get_tenants(), ["TENANT"]
-        )
-        self.assertEqual(
-            self.output_multitenant_check_entity.get_tenants(),
-            ["TENANT1", "TENANT2"]
-        )
+        self.assertEqual(self.output_multitenant_check.get_tenants(), ["TENANT"])
+        self.assertEqual(self.output_multitenant_check_entity.get_tenants(), ["TENANT1", "TENANT2"])
 
 
 class SensuCheckCallTests(unittest.TestCase):
@@ -9455,28 +7714,21 @@ class SensuCheckCallTests(unittest.TestCase):
         self.sensu = Sensu(
             url="https://mock.url.com",
             token="t0k3n",
-            namespaces={
-                "default": ["default"],
-                "tenant1": ["TENANT1"],
-                "tenant2": ["TENANT2"]
-            }
+            namespaces={"default": ["default"], "tenant1": ["TENANT1"], "tenant2": ["TENANT2"]},
         )
         self.checks = [
             {
                 "command": "/usr/lib64/nagios/plugins/check_http "
-                           "-H {{ .labels.hostname }} -t 60 --link "
-                           "--onredirect follow "
-                           "{{ .labels.ssl }} "
-                           "-p {{ .labels.port }} ",
-                "subscriptions": [
-                    "entity:sensu-agent1"
-                ],
+                "-H {{ .labels.hostname }} -t 60 --link "
+                "--onredirect follow "
+                "{{ .labels.ssl }} "
+                "-p {{ .labels.port }} ",
+                "subscriptions": ["entity:sensu-agent1"],
                 "handlers": [],
                 "proxy_requests": {
                     "entity_attributes": [
                         "entity.entity_class == 'proxy'",
-                        "entity.labels.generic_http_connect == "
-                        "'generic.http.connect'"
+                        "entity.labels.generic_http_connect == 'generic.http.connect'",
                     ]
                 },
                 "interval": 300,
@@ -9485,34 +7737,22 @@ class SensuCheckCallTests(unittest.TestCase):
                 "metadata": {
                     "name": "generic.http.connect",
                     "namespace": "default",
-                    "annotations": {
-                        "attempts": "3"
-                    },
-                    "labels": {
-                        "tenants": "default"
-                    }
+                    "annotations": {"attempts": "3"},
+                    "labels": {"tenants": "default"},
                 },
                 "round_robin": False,
-                "pipelines": [
-                    {
-                        "name": "hard_state",
-                        "type": "Pipeline",
-                        "api_version": "core/v2"
-                    }
-                ]
+                "pipelines": [{"name": "hard_state", "type": "Pipeline", "api_version": "core/v2"}],
             },
             {
                 "command": "/usr/lib64/nagios/plugins/check_tcp "
-                           "-H {{ .labels.hostname }} -t 120 -p 443",
+                "-H {{ .labels.hostname }} -t 120 -p 443",
                 "handlers": [],
                 "high_flap_threshold": 0,
                 "interval": 300,
                 "low_flap_threshold": 0,
                 "publish": True,
                 "runtime_assets": None,
-                "subscriptions": [
-                    "entity:sensu-agent1"
-                ],
+                "subscriptions": ["entity:sensu-agent1"],
                 "proxy_entity_name": "",
                 "check_hooks": None,
                 "stdin": False,
@@ -9522,11 +7762,10 @@ class SensuCheckCallTests(unittest.TestCase):
                 "proxy_requests": {
                     "entity_attributes": [
                         "entity.entity_class == 'proxy'",
-                        "entity.labels.generic_tcp_connect == "
-                        "'generic.tcp.connect'"
+                        "entity.labels.generic_tcp_connect == 'generic.tcp.connect'",
                     ],
                     "splay": False,
-                    "splay_coverage": 0
+                    "splay_coverage": 0,
                 },
                 "round_robin": True,
                 "output_metric_format": "",
@@ -9536,28 +7775,22 @@ class SensuCheckCallTests(unittest.TestCase):
                     "name": "generic.tcp.connect",
                     "namespace": "default",
                     "created_by": "root",
-                    "annotations": {
-                        "attempts": "3"
-                    },
-                    "labels": {
-                        "tenants": "default"
-                    }
+                    "annotations": {"attempts": "3"},
+                    "labels": {"tenants": "default"},
                 },
                 "secrets": None,
-                "pipelines": []
+                "pipelines": [],
             },
             {
                 "command": "/usr/libexec/argo/probes/cert/CertLifetime-probe "
-                           "-f /etc/sensu/certs/robotcert.pem",
+                "-f /etc/sensu/certs/robotcert.pem",
                 "handlers": [],
                 "high_flap_threshold": 0,
                 "interval": 14400,
                 "low_flap_threshold": 0,
                 "publish": True,
                 "runtime_assets": None,
-                "subscriptions": [
-                    "entity:sensu-agent1"
-                ],
+                "subscriptions": ["entity:sensu-agent1"],
                 "proxy_entity_name": "",
                 "check_hooks": None,
                 "stdin": False,
@@ -9571,35 +7804,25 @@ class SensuCheckCallTests(unittest.TestCase):
                 "metadata": {
                     "name": "srce.certificate.validity-robot",
                     "namespace": "default",
-                    "annotations": {
-                        "attempts": "2"
-                    },
-                    "labels": {
-                        "tenants": "default"
-                    }
+                    "annotations": {"attempts": "2"},
+                    "labels": {"tenants": "default"},
                 },
                 "secrets": None,
                 "pipelines": [
-                    {
-                        "name": "reduce_alerts",
-                        "type": "Pipeline",
-                        "api_version": "core/v2"
-                    }
-                ]
-            }
+                    {"name": "reduce_alerts", "type": "Pipeline", "api_version": "core/v2"}
+                ],
+            },
         ]
         self.entities = [
             {
                 "entity_class": "proxy",
                 "system": {
-                    "network": {
-                        "interfaces": None
-                    },
+                    "network": {"interfaces": None},
                     "libc_type": "",
                     "vm_system": "",
                     "vm_role": "",
                     "cloud_provider": "",
-                    "processes": None
+                    "processes": None,
                 },
                 "subscriptions": None,
                 "last_seen": 0,
@@ -9614,22 +7837,20 @@ class SensuCheckCallTests(unittest.TestCase):
                         "ssl": "-S --sni",
                         "port": "443",
                         "generic_tcp_connect": "generic.tcp.connect",
-                        "generic_http_connect": "generic.http.connect"
-                    }
+                        "generic_http_connect": "generic.http.connect",
+                    },
                 },
-                "sensu_agent_version": ""
+                "sensu_agent_version": "",
             },
             {
                 "entity_class": "proxy",
                 "system": {
-                    "network": {
-                        "interfaces": None
-                    },
+                    "network": {"interfaces": None},
                     "libc_type": "",
                     "vm_system": "",
                     "vm_role": "",
                     "cloud_provider": "",
-                    "processes": None
+                    "processes": None,
                 },
                 "subscriptions": None,
                 "last_seen": 0,
@@ -9644,10 +7865,10 @@ class SensuCheckCallTests(unittest.TestCase):
                         "ssl": "-S --sni",
                         "port": "443",
                         "path": "/some/path",
-                        "generic_http_connect": "generic.http.connect"
-                    }
+                        "generic_http_connect": "generic.http.connect",
+                    },
                 },
-                "sensu_agent_version": ""
+                "sensu_agent_version": "",
             },
             {
                 "entity_class": "agent",
@@ -9659,15 +7880,12 @@ class SensuCheckCallTests(unittest.TestCase):
                     "platform_version": "7.8.2003",
                     "network": {
                         "interfaces": [
-                            {
-                                "name": "lo",
-                                "addresses": ["xxx.x.x.x/x"]
-                            },
+                            {"name": "lo", "addresses": ["xxx.x.x.x/x"]},
                             {
                                 "name": "eth0",
                                 "mac": "xx:xx:xx:xx:xx:xx",
-                                "addresses": ["xx.x.xxx.xxx/xx"]
-                            }
+                                "addresses": ["xx.x.xxx.xxx/xx"],
+                            },
                         ]
                     },
                     "arch": "amd64",
@@ -9675,12 +7893,9 @@ class SensuCheckCallTests(unittest.TestCase):
                     "vm_system": "",
                     "vm_role": "guest",
                     "cloud_provider": "",
-                    "processes": None
+                    "processes": None,
                 },
-                "subscriptions": [
-                    "entity:sensu-agent1",
-                    "default"
-                ],
+                "subscriptions": ["entity:sensu-agent1", "default"],
                 "last_seen": 1645005291,
                 "deregister": False,
                 "deregistration": {},
@@ -9694,17 +7909,15 @@ class SensuCheckCallTests(unittest.TestCase):
                     "access_key",
                     "secret_key",
                     "private_key",
-                    "secret"
+                    "secret",
                 ],
                 "metadata": {
                     "name": "sensu-agent1",
                     "namespace": "default",
-                    "labels": {
-                        "hostname": "sensu-agent1"
-                    }
+                    "labels": {"hostname": "sensu-agent1"},
                 },
-                "sensu_agent_version": "6.6.3"
-            }
+                "sensu_agent_version": "6.6.3",
+            },
         ]
 
     @patch("argo_scg.sensu.Sensu._get_entities")
@@ -9712,20 +7925,13 @@ class SensuCheckCallTests(unittest.TestCase):
     def test_get_check_run(self, return_checks, return_entities):
         return_checks.return_value = self.checks
         return_entities.return_value = self.entities
-        run, timeout = self.sensu.get_check_run(
-            entity="argo.ni4os.eu", check="generic.tcp.connect"
-        )
-        self.assertEqual(
-            run,
-            "/usr/lib64/nagios/plugins/check_tcp -H argo.ni4os.eu -t 120 -p 443"
-        )
+        run, timeout = self.sensu.get_check_run(entity="argo.ni4os.eu", check="generic.tcp.connect")
+        self.assertEqual(run, "/usr/lib64/nagios/plugins/check_tcp -H argo.ni4os.eu -t 120 -p 443")
         self.assertEqual(timeout, 120)
 
     @patch("argo_scg.sensu.Sensu._get_entities")
     @patch("argo_scg.sensu.Sensu._get_checks")
-    def test_get_check_run_if_multiple_labels(
-            self, return_checks, return_entities
-    ):
+    def test_get_check_run_if_multiple_labels(self, return_checks, return_entities):
         return_checks.return_value = self.checks
         return_entities.return_value = self.entities
         run, timeout = self.sensu.get_check_run(
@@ -9734,21 +7940,21 @@ class SensuCheckCallTests(unittest.TestCase):
         self.assertEqual(
             run,
             "/usr/lib64/nagios/plugins/check_http -H argo.ni4os.eu "
-            "-t 60 --link --onredirect follow -S --sni -p 443"
+            "-t 60 --link --onredirect follow -S --sni -p 443",
         )
         self.assertEqual(timeout, 60)
 
     @patch("argo_scg.sensu.Sensu._get_entities")
     @patch("argo_scg.sensu.Sensu._get_checks")
-    def test_get_check_run_if_labels_with_defaults(
-            self, return_checks, return_entities
-    ):
+    def test_get_check_run_if_labels_with_defaults(self, return_checks, return_entities):
         checks = self.checks.copy()
-        checks[0]["command"] = "/usr/lib64/nagios/plugins/check_http "\
-                               "-H {{ .labels.hostname }} -t 60 --link "\
-                               "--onredirect follow {{ .labels.ssl }} "\
-                               "-p {{ .labels.port }} " \
-                               "-u {{ .labels.path | default \"/\" }}"
+        checks[0]["command"] = (
+            "/usr/lib64/nagios/plugins/check_http "
+            "-H {{ .labels.hostname }} -t 60 --link "
+            "--onredirect follow {{ .labels.ssl }} "
+            "-p {{ .labels.port }} "
+            '-u {{ .labels.path | default "/" }}'
+        )
         return_checks.return_value = checks
         return_entities.return_value = self.entities
         run1, timeout1 = self.sensu.get_check_run(
@@ -9760,56 +7966,44 @@ class SensuCheckCallTests(unittest.TestCase):
         self.assertEqual(
             run1,
             "/usr/lib64/nagios/plugins/check_http -H argo.ni4os.eu "
-            "-t 60 --link --onredirect follow -S --sni -p 443 -u /"
+            "-t 60 --link --onredirect follow -S --sni -p 443 -u /",
         )
         self.assertEqual(timeout1, 60)
         self.assertEqual(
             run2,
             "/usr/lib64/nagios/plugins/check_http -H argo2.ni4os.eu "
-            "-t 60 --link --onredirect follow -S --sni -p 443 -u /some/path"
+            "-t 60 --link --onredirect follow -S --sni -p 443 -u /some/path",
         )
         self.assertEqual(timeout2, 60)
 
     @patch("argo_scg.sensu.Sensu._get_entities")
     @patch("argo_scg.sensu.Sensu._get_checks")
-    def test_get_check_run_if_nonexisting_check(
-            self, return_checks, return_entities
-    ):
+    def test_get_check_run_if_nonexisting_check(self, return_checks, return_entities):
         return_checks.return_value = self.checks
         return_entities.return_value = self.entities
         with self.assertRaises(SensuException) as context:
-            self.sensu.get_check_run(
-                entity="argo.ni4os.eu", check="generic.certificate.validity"
-            )
+            self.sensu.get_check_run(entity="argo.ni4os.eu", check="generic.certificate.validity")
 
         self.assertEqual(
             context.exception.__str__(),
-            "Sensu error: No check generic.certificate.validity in namespace "
-            "default"
+            "Sensu error: No check generic.certificate.validity in namespace default",
         )
 
     @patch("argo_scg.sensu.Sensu._get_entities")
     @patch("argo_scg.sensu.Sensu._get_checks")
-    def test_get_check_run_if_nonexisting_entity(
-            self, return_checks, return_entities
-    ):
+    def test_get_check_run_if_nonexisting_entity(self, return_checks, return_entities):
         return_checks.return_value = self.checks
         return_entities.return_value = self.entities
         with self.assertRaises(SensuException) as context:
-            self.sensu.get_check_run(
-                entity="argo.egi.eu", check="generic.http.connect"
-            )
+            self.sensu.get_check_run(entity="argo.egi.eu", check="generic.http.connect")
 
         self.assertEqual(
-            context.exception.__str__(),
-            "Sensu error: No entity argo.egi.eu in namespace default"
+            context.exception.__str__(), "Sensu error: No entity argo.egi.eu in namespace default"
         )
 
     @patch("argo_scg.sensu.Sensu._get_entities")
     @patch("argo_scg.sensu.Sensu._get_checks")
-    def test_get_check_run_if_entity_is_agent(
-            self, return_checks, return_entities
-    ):
+    def test_get_check_run_if_entity_is_agent(self, return_checks, return_entities):
         return_checks.return_value = self.checks
         return_entities.return_value = self.entities
         run, timeout = self.sensu.get_check_run(
@@ -9817,44 +8011,37 @@ class SensuCheckCallTests(unittest.TestCase):
         )
         self.assertEqual(
             run,
-            "/usr/libexec/argo/probes/cert/CertLifetime-probe -f "
-            "/etc/sensu/certs/robotcert.pem"
+            "/usr/libexec/argo/probes/cert/CertLifetime-probe -f /etc/sensu/certs/robotcert.pem",
         )
         self.assertEqual(timeout, 900)
 
     @patch("argo_scg.sensu.Sensu._get_entities")
     @patch("argo_scg.sensu.Sensu._get_checks")
     def test_get_check_run_if_entity_is_agent_and_nonexisting_event(
-            self, return_checks, return_entities
+        self, return_checks, return_entities
     ):
         return_checks.return_value = self.checks
         return_entities.return_value = self.entities
         with self.assertRaises(SensuException) as context:
-            self.sensu.get_check_run(
-                entity="sensu-agent1", check="generic.http.connect"
-            )
+            self.sensu.get_check_run(entity="sensu-agent1", check="generic.http.connect")
         self.assertEqual(
             context.exception.__str__(),
             "Sensu error: No event with entity sensu-agent1 and check "
-            "generic.http.connect in namespace default"
+            "generic.http.connect in namespace default",
         )
 
     @patch("argo_scg.sensu.Sensu._get_entities")
     @patch("argo_scg.sensu.Sensu._get_checks")
-    def test_get_check_run_if_nonexisting_event(
-            self, return_checks, return_entities
-    ):
+    def test_get_check_run_if_nonexisting_event(self, return_checks, return_entities):
         return_checks.return_value = self.checks
         return_entities.return_value = self.entities
         with self.assertRaises(SensuException) as context:
-            self.sensu.get_check_run(
-                entity="argo2.ni4os.eu", check="generic.tcp.connect"
-            )
+            self.sensu.get_check_run(entity="argo2.ni4os.eu", check="generic.tcp.connect")
 
         self.assertEqual(
             context.exception.__str__(),
             "Sensu error: No event with entity argo2.ni4os.eu and check "
-            "generic.tcp.connect in namespace default"
+            "generic.tcp.connect in namespace default",
         )
 
     @patch("argo_scg.sensu.Sensu._get_checks")
@@ -9862,39 +8049,27 @@ class SensuCheckCallTests(unittest.TestCase):
         return_checks.return_value = self.checks
         self.assertEqual(
             self.sensu.get_check_subscriptions(check="generic.http.connect"),
-            ["entity:sensu-agent1"]
+            ["entity:sensu-agent1"],
         )
         self.assertEqual(
-            self.sensu.get_check_subscriptions(check="generic.tcp.connect"), [
-                "entity:sensu-agent1"
-            ]
+            self.sensu.get_check_subscriptions(check="generic.tcp.connect"), ["entity:sensu-agent1"]
         )
 
     @patch("argo_scg.sensu.Sensu._get_entities")
     def test_is_entity_agent(self, return_entities):
         return_entities.return_value = self.entities
-        self.assertTrue(
-            self.sensu.is_entity_agent(
-                entity="sensu-agent1", namespace="default"
-            )
-        )
-        self.assertFalse(
-            self.sensu.is_entity_agent(
-                entity="argo2.ni4os.eu", namespace="default"
-            )
-        )
+        self.assertTrue(self.sensu.is_entity_agent(entity="sensu-agent1", namespace="default"))
+        self.assertFalse(self.sensu.is_entity_agent(entity="argo2.ni4os.eu", namespace="default"))
 
     @patch("argo_scg.sensu.Sensu._get_entities")
     def test_is_entity_agent_if_nonexisting_entity(self, return_entities):
         return_entities.return_value = self.entities
         with self.assertRaises(SensuException) as context:
-            self.sensu.is_entity_agent(
-                entity="nonexisting-entity", namespace="default"
-            )
+            self.sensu.is_entity_agent(entity="nonexisting-entity", namespace="default")
 
         self.assertEqual(
             context.exception.__str__(),
-            "Sensu error: No entity nonexisting-entity in namespace default"
+            "Sensu error: No entity nonexisting-entity in namespace default",
         )
 
 
@@ -9903,140 +8078,111 @@ class SensuSilencingEntryTests(unittest.TestCase):
         self.sensu = Sensu(
             url="https://mock.url.com",
             token="t0k3n",
-            namespaces={
-                "default": ["default"],
-                "tenant1": ["TENANT1"],
-                "tenant2": ["TENANT2"]
-            }
+            namespaces={"default": ["default"], "tenant1": ["TENANT1"], "tenant2": ["TENANT2"]},
         )
 
     @patch("argo_scg.sensu.Sensu._get_events")
     @patch("requests.post")
     def test_create_silencing_entry(self, mock_post, mock_get_events):
         mock_post.side_effect = mock_post_response
-        mock_get_events.return_value = MockResponse(
-            mock_events, status_code=200
-        )
+        mock_get_events.return_value = MockResponse(mock_events, status_code=200)
         self.sensu.create_silencing_entry(
-            check="generic.tcp.connect",
-            entity="gocdb.ni4os.eu",
-            namespace="tenant1"
+            check="generic.tcp.connect", entity="gocdb.ni4os.eu", namespace="tenant1"
         )
         mock_post.assert_called_once_with(
             "https://mock.url.com/api/core/v2/namespaces/tenant1/silenced",
-            data=json.dumps({
-                "metadata": {
-                    "name": "entity:gocdb.ni4os.eu:generic.tcp.connect",
-                    "namespace": "tenant1"
-                },
-                "expire_on_resolve": True,
-                "check": "generic.tcp.connect",
-                "subscription": "entity:gocdb.ni4os.eu"
-            }),
-            headers={
-                "Authorization": "Key t0k3n",
-                "Content-Type": "application/json"
-            }
+            data=json.dumps(
+                {
+                    "metadata": {
+                        "name": "entity:gocdb.ni4os.eu:generic.tcp.connect",
+                        "namespace": "tenant1",
+                    },
+                    "expire_on_resolve": True,
+                    "check": "generic.tcp.connect",
+                    "subscription": "entity:gocdb.ni4os.eu",
+                }
+            ),
+            headers={"Authorization": "Key t0k3n", "Content-Type": "application/json"},
         )
 
     @patch("argo_scg.sensu.Sensu._get_events")
     @patch("requests.post")
-    def test_create_silencing_entry_with_error_with_message(
-            self, mock_post, mock_get_events
-    ):
+    def test_create_silencing_entry_with_error_with_message(self, mock_post, mock_get_events):
         mock_post.return_value = MockResponse(
             {"message": "There has been an error"}, status_code=400
         )
-        mock_get_events.return_value = MockResponse(
-            mock_events, status_code=200
-        )
+        mock_get_events.return_value = MockResponse(mock_events, status_code=200)
         with self.assertRaises(SensuException) as context:
             self.sensu.create_silencing_entry(
-                check="generic.tcp.connect",
-                entity="gocdb.ni4os.eu",
-                namespace="tenant1"
+                check="generic.tcp.connect", entity="gocdb.ni4os.eu", namespace="tenant1"
             )
         mock_post.assert_called_once_with(
             "https://mock.url.com/api/core/v2/namespaces/tenant1/silenced",
-            data=json.dumps({
-                "metadata": {
-                    "name": "entity:gocdb.ni4os.eu:generic.tcp.connect",
-                    "namespace": "tenant1"
-                },
-                "expire_on_resolve": True,
-                "check": "generic.tcp.connect",
-                "subscription": "entity:gocdb.ni4os.eu"
-            }),
-            headers={
-                "Authorization": "Key t0k3n",
-                "Content-Type": "application/json"
-            }
+            data=json.dumps(
+                {
+                    "metadata": {
+                        "name": "entity:gocdb.ni4os.eu:generic.tcp.connect",
+                        "namespace": "tenant1",
+                    },
+                    "expire_on_resolve": True,
+                    "check": "generic.tcp.connect",
+                    "subscription": "entity:gocdb.ni4os.eu",
+                }
+            ),
+            headers={"Authorization": "Key t0k3n", "Content-Type": "application/json"},
         )
         self.assertEqual(
             context.exception.__str__(),
             "Sensu error: tenant1: Silencing entry gocdb.ni4os.eu/"
             "generic.tcp.connect create error: 400 BAD REQUEST: "
-            "There has been an error"
+            "There has been an error",
         )
 
     @patch("argo_scg.sensu.Sensu._get_events")
     @patch("requests.post")
-    def test_create_silencing_entry_with_error_without_message(
-            self, mock_post, mock_get_events
-    ):
+    def test_create_silencing_entry_with_error_without_message(self, mock_post, mock_get_events):
         mock_post.return_value = MockResponse(None, status_code=400)
-        mock_get_events.return_value = MockResponse(
-            mock_events, status_code=200
-        )
+        mock_get_events.return_value = MockResponse(mock_events, status_code=200)
         with self.assertRaises(SensuException) as context:
             self.sensu.create_silencing_entry(
-                check="generic.tcp.connect",
-                entity="gocdb.ni4os.eu",
-                namespace="tenant1"
+                check="generic.tcp.connect", entity="gocdb.ni4os.eu", namespace="tenant1"
             )
         mock_post.assert_called_once_with(
             "https://mock.url.com/api/core/v2/namespaces/tenant1/silenced",
-            data=json.dumps({
-                "metadata": {
-                    "name": "entity:gocdb.ni4os.eu:generic.tcp.connect",
-                    "namespace": "tenant1"
-                },
-                "expire_on_resolve": True,
-                "check": "generic.tcp.connect",
-                "subscription": "entity:gocdb.ni4os.eu"
-            }),
-            headers={
-                "Authorization": "Key t0k3n",
-                "Content-Type": "application/json"
-            }
+            data=json.dumps(
+                {
+                    "metadata": {
+                        "name": "entity:gocdb.ni4os.eu:generic.tcp.connect",
+                        "namespace": "tenant1",
+                    },
+                    "expire_on_resolve": True,
+                    "check": "generic.tcp.connect",
+                    "subscription": "entity:gocdb.ni4os.eu",
+                }
+            ),
+            headers={"Authorization": "Key t0k3n", "Content-Type": "application/json"},
         )
         self.assertEqual(
             context.exception.__str__(),
             "Sensu error: tenant1: Silencing entry gocdb.ni4os.eu/"
-            "generic.tcp.connect create error: 400 BAD REQUEST"
+            "generic.tcp.connect create error: 400 BAD REQUEST",
         )
 
     @patch("argo_scg.sensu.Sensu._get_events")
     @patch("requests.post")
-    def test_create_silencing_entry_if_nonexisting_event(
-            self, mock_post, mock_get_events
-    ):
+    def test_create_silencing_entry_if_nonexisting_event(self, mock_post, mock_get_events):
         mock_post.side_effect = mock_post_response
-        mock_get_events.return_value = MockResponse(
-            mock_events, status_code=200
-        )
+        mock_get_events.return_value = MockResponse(mock_events, status_code=200)
         with self.assertRaises(SensuException) as context:
             self.sensu.create_silencing_entry(
-                check="generic.http.connect",
-                entity="argo.ni4os.eu",
-                namespace="tenant1"
+                check="generic.http.connect", entity="argo.ni4os.eu", namespace="tenant1"
             )
         self.assertEqual(mock_post.call_count, 0)
 
         self.assertEqual(
             context.exception.__str__(),
             "Sensu error: tenant1: No event for entity argo.ni4os.eu and check "
-            "generic.http.connect: Silencing entry not created"
+            "generic.http.connect: Silencing entry not created",
         )
 
     @patch("argo_scg.sensu.requests.get")
@@ -10045,7 +8191,7 @@ class SensuSilencingEntryTests(unittest.TestCase):
         silenced_entries = self.sensu._get_silenced_entries(namespace="tenant1")
         mock_get.assert_called_once_with(
             "https://mock.url.com/api/core/v2/namespaces/tenant1/silenced",
-            headers={"Authorization": "Key t0k3n"}
+            headers={"Authorization": "Key t0k3n"},
         )
         self.assertEqual(silenced_entries, mock_silenced)
 
@@ -10056,12 +8202,12 @@ class SensuSilencingEntryTests(unittest.TestCase):
             self.sensu._get_silenced_entries(namespace="tenant1")
         mock_get.assert_called_once_with(
             "https://mock.url.com/api/core/v2/namespaces/tenant1/silenced",
-            headers={"Authorization": "Key t0k3n"}
+            headers={"Authorization": "Key t0k3n"},
         )
         self.assertEqual(
             context.exception.__str__(),
             "Sensu error: tenant1: Silenced entries fetch error: "
-            "400 BAD REQUEST: Something went wrong."
+            "400 BAD REQUEST: Something went wrong.",
         )
 
     @patch("argo_scg.sensu.requests.get")
@@ -10071,12 +8217,11 @@ class SensuSilencingEntryTests(unittest.TestCase):
             self.sensu._get_silenced_entries(namespace="tenant1")
         mock_get.assert_called_once_with(
             "https://mock.url.com/api/core/v2/namespaces/tenant1/silenced",
-            headers={"Authorization": "Key t0k3n"}
+            headers={"Authorization": "Key t0k3n"},
         )
         self.assertEqual(
             context.exception.__str__(),
-            "Sensu error: tenant1: Silenced entries fetch error: "
-            "400 BAD REQUEST"
+            "Sensu error: tenant1: Silenced entries fetch error: 400 BAD REQUEST",
         )
 
     @patch("argo_scg.sensu.requests.delete")
@@ -10085,198 +8230,190 @@ class SensuSilencingEntryTests(unittest.TestCase):
         mock_silenced_entries.return_value = mock_silenced
         mock_delete.side_effect = mock_delete_response
         self.sensu._delete_silenced_entry(
-            entity="hostname1.example.com",
-            check="generic.tcp.connect",
-            namespace="tenant1"
+            entity="hostname1.example.com", check="generic.tcp.connect", namespace="tenant1"
         )
         mock_delete.assert_called_once_with(
             "https://mock.url.com/api/core/v2/namespaces/tenant1/silenced/"
             "entity:hostname1.example.com:generic.tcp.connect",
-            headers={"Authorization": "Key t0k3n"}
+            headers={"Authorization": "Key t0k3n"},
         )
 
     @patch("argo_scg.sensu.requests.delete")
     @patch("argo_scg.sensu.Sensu._get_silenced_entries")
-    def test_delete_silenced_entry_with_only_entity_given(
-            self, mock_silenced_entries, mock_delete
-    ):
+    def test_delete_silenced_entry_with_only_entity_given(self, mock_silenced_entries, mock_delete):
         mock_silenced_entries.return_value = mock_silenced
         mock_delete.side_effect = mock_delete_response
-        self.sensu._delete_silenced_entry(
-            entity="hostname1.example.com",
-            namespace="tenant1"
-        )
+        self.sensu._delete_silenced_entry(entity="hostname1.example.com", namespace="tenant1")
         self.assertEqual(mock_delete.call_count, 2)
-        mock_delete.assert_has_calls([
-            call(
-                "https://mock.url.com/api/core/v2/namespaces/tenant1/silenced/"
-                "entity:hostname1.example.com:generic.tcp.connect",
-                headers={"Authorization": "Key t0k3n"}
-            ),
-            call(
-                "https://mock.url.com/api/core/v2/namespaces/tenant1/silenced/"
-                "entity:hostname1.example.com:generic.certificate.validity",
-                headers={"Authorization": "Key t0k3n"}
-            )
-        ], any_order=True)
+        mock_delete.assert_has_calls(
+            [
+                call(
+                    "https://mock.url.com/api/core/v2/namespaces/tenant1/silenced/"
+                    "entity:hostname1.example.com:generic.tcp.connect",
+                    headers={"Authorization": "Key t0k3n"},
+                ),
+                call(
+                    "https://mock.url.com/api/core/v2/namespaces/tenant1/silenced/"
+                    "entity:hostname1.example.com:generic.certificate.validity",
+                    headers={"Authorization": "Key t0k3n"},
+                ),
+            ],
+            any_order=True,
+        )
 
     @patch("argo_scg.sensu.requests.delete")
     @patch("argo_scg.sensu.Sensu._get_silenced_entries")
-    def test_delete_silenced_entry_with_only_check_given(
-            self, mock_silenced_entries, mock_delete
-    ):
+    def test_delete_silenced_entry_with_only_check_given(self, mock_silenced_entries, mock_delete):
         mock_silenced_entries.return_value = mock_silenced
         mock_delete.side_effect = mock_delete_response
-        self.sensu._delete_silenced_entry(
-            check="generic.tcp.connect",
-            namespace="tenant1"
-        )
+        self.sensu._delete_silenced_entry(check="generic.tcp.connect", namespace="tenant1")
         self.assertEqual(mock_delete.call_count, 2)
-        mock_delete.assert_has_calls([
-            call(
-                "https://mock.url.com/api/core/v2/namespaces/tenant1/silenced/"
-                "entity:hostname1.example.com:generic.tcp.connect",
-                headers={"Authorization": "Key t0k3n"}
-            ),
-            call(
-                "https://mock.url.com/api/core/v2/namespaces/tenant1/silenced/"
-                "entity:hostname2.example.com:generic.tcp.connect",
-                headers={"Authorization": "Key t0k3n"}
-            )
-        ], any_order=True)
+        mock_delete.assert_has_calls(
+            [
+                call(
+                    "https://mock.url.com/api/core/v2/namespaces/tenant1/silenced/"
+                    "entity:hostname1.example.com:generic.tcp.connect",
+                    headers={"Authorization": "Key t0k3n"},
+                ),
+                call(
+                    "https://mock.url.com/api/core/v2/namespaces/tenant1/silenced/"
+                    "entity:hostname2.example.com:generic.tcp.connect",
+                    headers={"Authorization": "Key t0k3n"},
+                ),
+            ],
+            any_order=True,
+        )
 
     @patch("argo_scg.sensu.requests.delete")
     @patch("argo_scg.sensu.Sensu._get_silenced_entries")
     def test_delete_silenced_entry_with_error_with_message(
-            self, mock_silenced_entries, mock_delete
+        self, mock_silenced_entries, mock_delete
     ):
         mock_silenced_entries.return_value = mock_silenced
-        mock_delete.side_effect = \
-            mock_delete_response_one_silenced_entry_not_ok_with_message
+        mock_delete.side_effect = mock_delete_response_one_silenced_entry_not_ok_with_message
         with self.assertRaises(SCGWarnException) as context:
-            self.sensu._delete_silenced_entry(
-                check="generic.tcp.connect",
-                namespace="tenant1"
-            )
+            self.sensu._delete_silenced_entry(check="generic.tcp.connect", namespace="tenant1")
         self.assertEqual(mock_delete.call_count, 2)
-        mock_delete.assert_has_calls([
-            call(
-                "https://mock.url.com/api/core/v2/namespaces/tenant1/silenced/"
-                "entity:hostname1.example.com:generic.tcp.connect",
-                headers={"Authorization": "Key t0k3n"}
-            ),
-            call(
-                "https://mock.url.com/api/core/v2/namespaces/tenant1/silenced/"
-                "entity:hostname2.example.com:generic.tcp.connect",
-                headers={"Authorization": "Key t0k3n"}
-            )
-        ], any_order=True)
+        mock_delete.assert_has_calls(
+            [
+                call(
+                    "https://mock.url.com/api/core/v2/namespaces/tenant1/silenced/"
+                    "entity:hostname1.example.com:generic.tcp.connect",
+                    headers={"Authorization": "Key t0k3n"},
+                ),
+                call(
+                    "https://mock.url.com/api/core/v2/namespaces/tenant1/silenced/"
+                    "entity:hostname2.example.com:generic.tcp.connect",
+                    headers={"Authorization": "Key t0k3n"},
+                ),
+            ],
+            any_order=True,
+        )
         self.assertEqual(
             context.exception.__str__(),
             "Silenced entry entity:hostname2.example.com:generic.tcp.connect "
             "(400 BAD REQUEST: Something went wrong) "
-            "not removed"
+            "not removed",
         )
 
     @patch("argo_scg.sensu.requests.delete")
     @patch("argo_scg.sensu.Sensu._get_silenced_entries")
     def test_delete_silenced_entry_with_multiple_errors_with_message(
-            self, mock_silenced_entries, mock_delete
+        self, mock_silenced_entries, mock_delete
     ):
         mock_silenced_entries.return_value = mock_silenced
         mock_delete.return_value = MockResponse(
             {"message": "Something went wrong"}, status_code=400
         )
         with self.assertRaises(SCGWarnException) as context:
-            self.sensu._delete_silenced_entry(
-                check="generic.tcp.connect",
-                namespace="tenant1"
-            )
+            self.sensu._delete_silenced_entry(check="generic.tcp.connect", namespace="tenant1")
         self.assertEqual(mock_delete.call_count, 2)
-        mock_delete.assert_has_calls([
-            call(
-                "https://mock.url.com/api/core/v2/namespaces/tenant1/silenced/"
-                "entity:hostname1.example.com:generic.tcp.connect",
-                headers={"Authorization": "Key t0k3n"}
-            ),
-            call(
-                "https://mock.url.com/api/core/v2/namespaces/tenant1/silenced/"
-                "entity:hostname2.example.com:generic.tcp.connect",
-                headers={"Authorization": "Key t0k3n"}
-            )
-        ], any_order=True)
+        mock_delete.assert_has_calls(
+            [
+                call(
+                    "https://mock.url.com/api/core/v2/namespaces/tenant1/silenced/"
+                    "entity:hostname1.example.com:generic.tcp.connect",
+                    headers={"Authorization": "Key t0k3n"},
+                ),
+                call(
+                    "https://mock.url.com/api/core/v2/namespaces/tenant1/silenced/"
+                    "entity:hostname2.example.com:generic.tcp.connect",
+                    headers={"Authorization": "Key t0k3n"},
+                ),
+            ],
+            any_order=True,
+        )
         self.assertEqual(
             context.exception.__str__(),
             "Silenced entries entity:hostname1.example.com:generic.tcp.connect "
             "(400 BAD REQUEST: Something went wrong), "
             "entity:hostname2.example.com:generic.tcp.connect "
             "(400 BAD REQUEST: Something went wrong) "
-            "not removed"
+            "not removed",
         )
 
     @patch("argo_scg.sensu.requests.delete")
     @patch("argo_scg.sensu.Sensu._get_silenced_entries")
     def test_delete_silenced_entry_with_error_without_message(
-            self, mock_silenced_entries, mock_delete
+        self, mock_silenced_entries, mock_delete
     ):
         mock_silenced_entries.return_value = mock_silenced
-        mock_delete.side_effect = \
-            mock_delete_response_one_silenced_entry_not_ok_without_message
+        mock_delete.side_effect = mock_delete_response_one_silenced_entry_not_ok_without_message
         with self.assertRaises(SCGWarnException) as context:
-            self.sensu._delete_silenced_entry(
-                check="generic.tcp.connect",
-                namespace="tenant1"
-            )
+            self.sensu._delete_silenced_entry(check="generic.tcp.connect", namespace="tenant1")
         self.assertEqual(mock_delete.call_count, 2)
-        mock_delete.assert_has_calls([
-            call(
-                "https://mock.url.com/api/core/v2/namespaces/tenant1/silenced/"
-                "entity:hostname1.example.com:generic.tcp.connect",
-                headers={"Authorization": "Key t0k3n"}
-            ),
-            call(
-                "https://mock.url.com/api/core/v2/namespaces/tenant1/silenced/"
-                "entity:hostname2.example.com:generic.tcp.connect",
-                headers={"Authorization": "Key t0k3n"}
-            )
-        ], any_order=True)
+        mock_delete.assert_has_calls(
+            [
+                call(
+                    "https://mock.url.com/api/core/v2/namespaces/tenant1/silenced/"
+                    "entity:hostname1.example.com:generic.tcp.connect",
+                    headers={"Authorization": "Key t0k3n"},
+                ),
+                call(
+                    "https://mock.url.com/api/core/v2/namespaces/tenant1/silenced/"
+                    "entity:hostname2.example.com:generic.tcp.connect",
+                    headers={"Authorization": "Key t0k3n"},
+                ),
+            ],
+            any_order=True,
+        )
         self.assertEqual(
             context.exception.__str__(),
             "Silenced entry entity:hostname2.example.com:generic.tcp.connect "
-            "(400 BAD REQUEST) not removed"
+            "(400 BAD REQUEST) not removed",
         )
 
     @patch("argo_scg.sensu.requests.delete")
     @patch("argo_scg.sensu.Sensu._get_silenced_entries")
     def test_delete_silenced_entry_with_multiple_errors_without_message(
-            self, mock_silenced_entries, mock_delete
+        self, mock_silenced_entries, mock_delete
     ):
         mock_silenced_entries.return_value = mock_silenced
         mock_delete.return_value = MockResponse(None, status_code=400)
         with self.assertRaises(SCGWarnException) as context:
-            self.sensu._delete_silenced_entry(
-                check="generic.tcp.connect",
-                namespace="tenant1"
-            )
+            self.sensu._delete_silenced_entry(check="generic.tcp.connect", namespace="tenant1")
         self.assertEqual(mock_delete.call_count, 2)
-        mock_delete.assert_has_calls([
-            call(
-                "https://mock.url.com/api/core/v2/namespaces/tenant1/silenced/"
-                "entity:hostname1.example.com:generic.tcp.connect",
-                headers={"Authorization": "Key t0k3n"}
-            ),
-            call(
-                "https://mock.url.com/api/core/v2/namespaces/tenant1/silenced/"
-                "entity:hostname2.example.com:generic.tcp.connect",
-                headers={"Authorization": "Key t0k3n"}
-            )
-        ], any_order=True)
+        mock_delete.assert_has_calls(
+            [
+                call(
+                    "https://mock.url.com/api/core/v2/namespaces/tenant1/silenced/"
+                    "entity:hostname1.example.com:generic.tcp.connect",
+                    headers={"Authorization": "Key t0k3n"},
+                ),
+                call(
+                    "https://mock.url.com/api/core/v2/namespaces/tenant1/silenced/"
+                    "entity:hostname2.example.com:generic.tcp.connect",
+                    headers={"Authorization": "Key t0k3n"},
+                ),
+            ],
+            any_order=True,
+        )
         self.assertEqual(
             context.exception.__str__(),
             "Silenced entries entity:hostname1.example.com:generic.tcp.connect "
             "(400 BAD REQUEST), "
             "entity:hostname2.example.com:generic.tcp.connect "
-            "(400 BAD REQUEST) not removed"
+            "(400 BAD REQUEST) not removed",
         )
 
 
@@ -10286,11 +8423,11 @@ class SensuCtlTests(unittest.TestCase):
 
     @patch("argo_scg.sensu.subprocess.check_output")
     def test_get_events(self, mock_subprocess):
-        mock_subprocess.return_value = \
-            json.dumps(mock_events_ctl).encode("utf-8")
+        mock_subprocess.return_value = json.dumps(mock_events_ctl).encode("utf-8")
         events = self.sensuctl.get_events()
         self.assertEqual(
-            events, [
+            events,
+            [
                 "Entity                                           "
                 "Metric                          Status    Executed           "
                 "  Output",
@@ -10298,45 +8435,45 @@ class SensuCtlTests(unittest.TestCase):
                 "_____________________________________________________________"
                 "___________",
                 "argo.mon__argo-mon-devel.ni4os.eu                "
-                "generic.certificate.validity    OK        2023-03-01 10:23:26"
+                "generic.certificate.validity    OK        2023-03-01 11:23:26"
                 "  SSL_CERT OK - x509 certificate '*.ni4os.eu' "
                 "(argo-mon-devel.ni4os.eu) from 'GEANT OV RSA CA 4' valid "
                 "until Apr 14 23:59:59 2023 GMT (expires in 44 days)",
                 "argo.mon__argo-mon-devel.ni4os.eu                "
-                "generic.http.connect-nagios-ui  OK        2023-03-01 10:28:16"
+                "generic.http.connect-nagios-ui  OK        2023-03-01 11:28:16"
                 "  HTTP OK: HTTP/1.1 200 OK - 121268 bytes in 0.051 second "
                 "response time",
                 "eu.eudat.itsm.spmt__agora.ni4os.eu               "
-                "grnet.agora.healthcheck         OK        2023-04-24 07:54:32"
+                "grnet.agora.healthcheck         OK        2023-04-24 09:54:32"
                 "  OK - Agora is up.",
                 "eu.ni4os.repo.publication__cherry.chem.bg.ac.rs  "
-                "generic.certificate.validity    OK        2023-04-24 06:23:32"
+                "generic.certificate.validity    OK        2023-04-24 08:23:32"
                 "  SSL_CERT OK - x509 certificate 'cherry.chem.bg.ac.rs' from "
                 "'R3' valid until Jul 21 19:32:45 2023 GMT (expires in "
                 "88 days)",
                 "eu.ni4os.repo.publication__videolectures.net     "
-                "generic.certificate.validity    CRITICAL  2023-03-01 10:23:31"
+                "generic.certificate.validity    CRITICAL  2023-03-01 11:23:31"
                 "  SSL_CERT CRITICAL videolectures.net: x509 certificate is "
                 "expired (was valid until Jul 10 07:29:06 2022 GMT)",
                 "sensu-agent-ni4os-devel.cro-ngi                  "
-                "argo.poem-tools.check           OK        2023-04-24 07:55:24"
+                "argo.poem-tools.check           OK        2023-04-24 09:55:24"
                 "  OK - The run finished successfully.",
                 "sensu-agent-ni4os-devel.cro-ngi                  "
-                "hr.srce.CertLifetime-Local      OK        2023-04-24 07:01:10"
+                "hr.srce.CertLifetime-Local      OK        2023-04-24 09:01:10"
                 "  CERT LIFETIME OK - Certificate will expire in 373.99 days "
-                "(May  2 06:53:47 2024 GMT)"
-            ]
+                "(May  2 06:53:47 2024 GMT)",
+            ],
         )
 
     @patch("argo_scg.sensu.subprocess.check_output")
     def test_get_events_if_multiple_tenants(self, mock_subprocess):
-        mock_subprocess.return_value = \
-            json.dumps(mock_events_ctl_multiple_tenants).encode("utf-8")
+        mock_subprocess.return_value = json.dumps(mock_events_ctl_multiple_tenants).encode("utf-8")
         sensuctl = SensuCtl(tenant="tenant2", namespace="default")
         events = self.sensuctl.get_events()
         events2 = sensuctl.get_events()
         self.assertEqual(
-            events, [
+            events,
+            [
                 "Entity                                           "
                 "Metric                          Status    Executed           "
                 "  Output",
@@ -10344,37 +8481,38 @@ class SensuCtlTests(unittest.TestCase):
                 "_____________________________________________________________"
                 "___________",
                 "argo.mon__argo-mon-devel.ni4os.eu                "
-                "generic.certificate.validity    OK        2023-03-01 10:23:26"
+                "generic.certificate.validity    OK        2023-03-01 11:23:26"
                 "  SSL_CERT OK - x509 certificate '*.ni4os.eu' "
                 "(argo-mon-devel.ni4os.eu) from 'GEANT OV RSA CA 4' valid "
                 "until Apr 14 23:59:59 2023 GMT (expires in 44 days)",
                 "argo.mon__argo-mon-devel.ni4os.eu                "
-                "generic.http.connect-nagios-ui  OK        2023-03-01 10:28:16"
+                "generic.http.connect-nagios-ui  OK        2023-03-01 11:28:16"
                 "  HTTP OK: HTTP/1.1 200 OK - 121268 bytes in 0.051 second "
                 "response time",
                 "eu.eudat.itsm.spmt__agora.ni4os.eu               "
-                "grnet.agora.healthcheck         OK        2023-04-24 07:54:32"
+                "grnet.agora.healthcheck         OK        2023-04-24 09:54:32"
                 "  OK - Agora is up.",
                 "eu.ni4os.repo.publication__cherry.chem.bg.ac.rs  "
-                "generic.certificate.validity    OK        2023-04-24 06:23:32"
+                "generic.certificate.validity    OK        2023-04-24 08:23:32"
                 "  SSL_CERT OK - x509 certificate 'cherry.chem.bg.ac.rs' from "
                 "'R3' valid until Jul 21 19:32:45 2023 GMT (expires in "
                 "88 days)",
                 "eu.ni4os.repo.publication__videolectures.net     "
-                "generic.certificate.validity    CRITICAL  2023-03-01 10:23:31"
+                "generic.certificate.validity    CRITICAL  2023-03-01 11:23:31"
                 "  SSL_CERT CRITICAL videolectures.net: x509 certificate is "
                 "expired (was valid until Jul 10 07:29:06 2022 GMT)",
                 "sensu-agent-ni4os-devel.cro-ngi                  "
-                "argo.poem-tools.check           OK        2023-04-24 07:55:24"
+                "argo.poem-tools.check           OK        2023-04-24 09:55:24"
                 "  OK - The run finished successfully.",
                 "sensu-agent-ni4os-devel.cro-ngi                  "
-                "hr.srce.CertLifetime-Local      OK        2023-04-24 07:01:10"
+                "hr.srce.CertLifetime-Local      OK        2023-04-24 09:01:10"
                 "  CERT LIFETIME OK - Certificate will expire in 373.99 days "
-                "(May  2 06:53:47 2024 GMT)"
-            ]
+                "(May  2 06:53:47 2024 GMT)",
+            ],
         )
         self.assertEqual(
-            events2, [
+            events2,
+            [
                 "Entity                             "
                 "Metric                      Status    Executed           "
                 "  Output",
@@ -10382,27 +8520,27 @@ class SensuCtlTests(unittest.TestCase):
                 "_________________________________________________________"
                 "___________",
                 "WebService__hostname.test.eu_id_3  "
-                "generic.http.connect        OK        2024-06-05 08:33:25"
-                "  <A HREF=\"https://hostname.test.eu:443/meh/\" target="
-                "\"_blank\">HTTP OK: HTTP/1.1 200 OK - 9743 bytes in 0.339 "
+                "generic.http.connect        OK        2024-06-05 10:33:25"
+                '  <A HREF="https://hostname.test.eu:443/meh/" target='
+                '"_blank">HTTP OK: HTTP/1.1 200 OK - 9743 bytes in 0.339 '
                 "second response time </A>",
                 "sensu-agent-ni4os-devel.cro-ngi    "
-                "argo.poem-tools.check       OK        2023-04-24 07:55:24"
+                "argo.poem-tools.check       OK        2023-04-24 09:55:24"
                 "  OK - The run finished successfully.",
                 "sensu-agent-ni4os-devel.cro-ngi    "
-                "hr.srce.CertLifetime-Local  OK        2023-04-24 07:01:10"
+                "hr.srce.CertLifetime-Local  OK        2023-04-24 09:01:10"
                 "  CERT LIFETIME OK - Certificate will expire in 373.99 days "
-                "(May  2 06:53:47 2024 GMT)"
-            ]
+                "(May  2 06:53:47 2024 GMT)",
+            ],
         )
 
     @patch("argo_scg.sensu.subprocess.check_output")
     def test_get_events_multiline_output(self, mock_subprocess):
-        mock_subprocess.return_value = \
-            json.dumps(mock_events_multiline_ctl).encode("utf-8")
+        mock_subprocess.return_value = json.dumps(mock_events_multiline_ctl).encode("utf-8")
         events = self.sensuctl.get_events()
         self.assertEqual(
-            events, [
+            events,
+            [
                 "Entity                                         "
                 "Metric                                Status    "
                 "Executed             Output",
@@ -10411,26 +8549,26 @@ class SensuCtlTests(unittest.TestCase):
                 "_____________________________",
                 "org.opensciencegrid.htcondorce__ce503.cern.ch  "
                 "argo.certificate.validity-htcondorce  OK        "
-                "2024-01-09 21:32:24  "
+                "2024-01-09 22:32:24  "
                 "OK - HTCondorCE certificate valid until Jul 11 10:51:04 2024 "
                 "UTC (expires in 183 days)",
                 "org.opensciencegrid.htcondorce__ce503.cern.ch  "
                 "ch.cern.HTCondorCE-JobState           OK        "
-                "2024-01-10 09:16:29  "
+                "2024-01-10 10:16:29  "
                 "OK - Job was successfully submitted (93770287)",
                 "org.opensciencegrid.htcondorce__ce503.cern.ch  "
                 "ch.cern.HTCondorCE-JobSubmit          OK        "
-                "2024-01-10 04:16:25  OK - Job successfully completed"
-            ]
+                "2024-01-10 05:16:25  OK - Job successfully completed",
+            ],
         )
 
     @patch("argo_scg.sensu.subprocess.check_output")
     def test_filter_events_by_status(self, mock_subprocess):
-        mock_subprocess.return_value = \
-            json.dumps(mock_events_ctl).encode("utf-8")
+        mock_subprocess.return_value = json.dumps(mock_events_ctl).encode("utf-8")
         events = self.sensuctl.filter_events(status=0)
         self.assertEqual(
-            events, [
+            events,
+            [
                 "Entity                                           "
                 "Metric                          Status    Executed           "
                 "  Output",
@@ -10438,62 +8576,62 @@ class SensuCtlTests(unittest.TestCase):
                 "_____________________________________________________________"
                 "___________",
                 "argo.mon__argo-mon-devel.ni4os.eu                "
-                "generic.certificate.validity    OK        2023-03-01 10:23:26"
+                "generic.certificate.validity    OK        2023-03-01 11:23:26"
                 "  SSL_CERT OK - x509 certificate '*.ni4os.eu' "
                 "(argo-mon-devel.ni4os.eu) from 'GEANT OV RSA CA 4' valid "
                 "until Apr 14 23:59:59 2023 GMT (expires in 44 days)",
                 "argo.mon__argo-mon-devel.ni4os.eu                "
-                "generic.http.connect-nagios-ui  OK        2023-03-01 10:28:16"
+                "generic.http.connect-nagios-ui  OK        2023-03-01 11:28:16"
                 "  HTTP OK: HTTP/1.1 200 OK - 121268 bytes in 0.051 second "
                 "response time",
                 "eu.eudat.itsm.spmt__agora.ni4os.eu               "
-                "grnet.agora.healthcheck         OK        2023-04-24 07:54:32"
+                "grnet.agora.healthcheck         OK        2023-04-24 09:54:32"
                 "  OK - Agora is up.",
                 "eu.ni4os.repo.publication__cherry.chem.bg.ac.rs  "
-                "generic.certificate.validity    OK        2023-04-24 06:23:32"
+                "generic.certificate.validity    OK        2023-04-24 08:23:32"
                 "  SSL_CERT OK - x509 certificate 'cherry.chem.bg.ac.rs' from "
                 "'R3' valid until Jul 21 19:32:45 2023 GMT (expires in "
                 "88 days)",
                 "sensu-agent-ni4os-devel.cro-ngi                  "
-                "argo.poem-tools.check           OK        2023-04-24 07:55:24"
+                "argo.poem-tools.check           OK        2023-04-24 09:55:24"
                 "  OK - The run finished successfully.",
                 "sensu-agent-ni4os-devel.cro-ngi                  "
-                "hr.srce.CertLifetime-Local      OK        2023-04-24 07:01:10"
+                "hr.srce.CertLifetime-Local      OK        2023-04-24 09:01:10"
                 "  CERT LIFETIME OK - Certificate will expire in 373.99 days "
-                "(May  2 06:53:47 2024 GMT)"
-            ]
+                "(May  2 06:53:47 2024 GMT)",
+            ],
         )
 
     @patch("argo_scg.sensu.subprocess.check_output")
     def test_filter_events_by_unknown_status(self, mock_subprocess):
-        mock_subprocess.return_value = \
-            json.dumps(mock_events_ctl_with_unknowns).encode("utf-8")
+        mock_subprocess.return_value = json.dumps(mock_events_ctl_with_unknowns).encode("utf-8")
         events = self.sensuctl.filter_events(status=3)
         self.assertEqual(
-            events, [
+            events,
+            [
                 "Entity                         "
                 "Metric                     Status    Executed           "
                 "  Output",
                 "_____________________________________________________"
                 "_____________________________________________",
                 "ARC-CE__hostname2.example.com  "
-                "org.nordugrid.ARC-CE-IGTF  UNKNOWN   2024-03-17 22:01:19  "
+                "org.nordugrid.ARC-CE-IGTF  UNKNOWN   2024-03-17 23:01:19  "
                 "Missing directory $X509_CERT_DIR (/etc/grid-security/"
                 "certificates).",
                 "ARC-CE__hostname2.example.com  "
-                "org.nordugrid.ARC-CE-IGTF  UNKNOWN   2024-03-17 22:01:23  "
+                "org.nordugrid.ARC-CE-IGTF  UNKNOWN   2024-03-17 23:01:23  "
                 "Missing directory $X509_CERT_DIR (/etc/grid-security/"
-                "certificates)."
-            ]
+                "certificates).",
+            ],
         )
 
     @patch("argo_scg.sensu.subprocess.check_output")
     def test_filter_events_by_service_type(self, mock_subprocess):
-        mock_subprocess.return_value = (
-            json.dumps(mock_events_ctl).encode("utf-8"))
+        mock_subprocess.return_value = json.dumps(mock_events_ctl).encode("utf-8")
         events = self.sensuctl.filter_events(service_type="argo.mon")
         self.assertEqual(
-            events, [
+            events,
+            [
                 "Entity                             "
                 "Metric                          Status    Executed           "
                 "  Output",
@@ -10501,34 +8639,31 @@ class SensuCtlTests(unittest.TestCase):
                 "_____________________________________________________________"
                 "___________",
                 "argo.mon__argo-mon-devel.ni4os.eu  "
-                "generic.certificate.validity    OK        2023-03-01 10:23:26"
+                "generic.certificate.validity    OK        2023-03-01 11:23:26"
                 "  SSL_CERT OK - x509 certificate '*.ni4os.eu' "
                 "(argo-mon-devel.ni4os.eu) from 'GEANT OV RSA CA 4' valid "
                 "until Apr 14 23:59:59 2023 GMT (expires in 44 days)",
                 "argo.mon__argo-mon-devel.ni4os.eu  "
-                "generic.http.connect-nagios-ui  OK        2023-03-01 10:28:16"
+                "generic.http.connect-nagios-ui  OK        2023-03-01 11:28:16"
                 "  HTTP OK: HTTP/1.1 200 OK - 121268 bytes in 0.051 second "
                 "response time",
                 "sensu-agent-ni4os-devel.cro-ngi    "
-                "argo.poem-tools.check           OK        2023-04-24 07:55:24"
+                "argo.poem-tools.check           OK        2023-04-24 09:55:24"
                 "  OK - The run finished successfully.",
                 "sensu-agent-ni4os-devel.cro-ngi    "
-                "hr.srce.CertLifetime-Local      OK        2023-04-24 07:01:10"
+                "hr.srce.CertLifetime-Local      OK        2023-04-24 09:01:10"
                 "  CERT LIFETIME OK - Certificate will expire in 373.99 days "
-                "(May  2 06:53:47 2024 GMT)"
-            ]
+                "(May  2 06:53:47 2024 GMT)",
+            ],
         )
 
     @patch("argo_scg.sensu.subprocess.check_output")
     def test_filter_events_by_status_and_service_type(self, mock_subprocess):
-        mock_subprocess.return_value = (
-            json.dumps(mock_events_ctl).encode("utf-8"))
-        events = self.sensuctl.filter_events(
-            status=0,
-            service_type="eu.ni4os.repo.publication"
-        )
+        mock_subprocess.return_value = json.dumps(mock_events_ctl).encode("utf-8")
+        events = self.sensuctl.filter_events(status=0, service_type="eu.ni4os.repo.publication")
         self.assertEqual(
-            events, [
+            events,
+            [
                 "Entity                                           "
                 "Metric                        Status    Executed           "
                 "  Output",
@@ -10536,20 +8671,21 @@ class SensuCtlTests(unittest.TestCase):
                 "___________________________________________________________"
                 "___________",
                 "eu.ni4os.repo.publication__cherry.chem.bg.ac.rs  "
-                "generic.certificate.validity  OK        2023-04-24 06:23:32"
+                "generic.certificate.validity  OK        2023-04-24 08:23:32"
                 "  SSL_CERT OK - x509 certificate 'cherry.chem.bg.ac.rs' from "
                 "'R3' valid until Jul 21 19:32:45 2023 GMT (expires in "
-                "88 days)"
-            ]
+                "88 days)",
+            ],
         )
 
     @patch("argo_scg.sensu.subprocess.check_output")
     def test_filter_agent_events(self, mock_subprocess):
-        mock_subprocess.return_value = \
-            json.dumps(mock_events_ctl).encode("utf-8")
+        mock_subprocess.return_value = json.dumps(mock_events_ctl).encode("utf-8")
         events = self.sensuctl.filter_events(agent=True)
+        print(events)
         self.assertEqual(
-            events, [
+            events,
+            [
                 "Entity                           "
                 "Metric                      Status    Executed           "
                 "  Output",
@@ -10557,24 +8693,23 @@ class SensuCtlTests(unittest.TestCase):
                 "_________________________________________________________"
                 "___________",
                 "sensu-agent-ni4os-devel.cro-ngi  "
-                "argo.poem-tools.check       OK        2023-04-24 07:55:24"
+                "argo.poem-tools.check       OK        2023-04-24 09:55:24"
                 "  OK - The run finished successfully.",
                 "sensu-agent-ni4os-devel.cro-ngi  "
-                "hr.srce.CertLifetime-Local  OK        2023-04-24 07:01:10"
+                "hr.srce.CertLifetime-Local  OK        2023-04-24 09:01:10"
                 "  CERT LIFETIME OK - Certificate will expire in 373.99 days "
-                "(May  2 06:53:47 2024 GMT)"
-            ]
+                "(May  2 06:53:47 2024 GMT)",
+            ],
         )
 
     @patch("argo_scg.sensu.subprocess.check_output")
     def test_filter_agent_events_by_service_type(self, mock_subprocess):
-        mock_subprocess.return_value = \
-            json.dumps(mock_events_ctl).encode("utf-8")
-        events = self.sensuctl.filter_events(
-            service_type="argo.mon", agent=True
-        )
+        mock_subprocess.return_value = json.dumps(mock_events_ctl).encode("utf-8")
+        events = self.sensuctl.filter_events(service_type="argo.mon", agent=True)
+        print(events)
         self.assertEqual(
-            events, [
+            events,
+            [
                 "Entity                           "
                 "Metric                      Status    Executed           "
                 "  Output",
@@ -10582,23 +8717,23 @@ class SensuCtlTests(unittest.TestCase):
                 "_________________________________________________________"
                 "___________",
                 "sensu-agent-ni4os-devel.cro-ngi  "
-                "argo.poem-tools.check       OK        2023-04-24 07:55:24"
+                "argo.poem-tools.check       OK        2023-04-24 09:55:24"
                 "  OK - The run finished successfully.",
                 "sensu-agent-ni4os-devel.cro-ngi  "
-                "hr.srce.CertLifetime-Local  OK        2023-04-24 07:01:10"
+                "hr.srce.CertLifetime-Local  OK        2023-04-24 09:01:10"
                 "  CERT LIFETIME OK - Certificate will expire in 373.99 days "
-                "(May  2 06:53:47 2024 GMT)"
-            ]
+                "(May  2 06:53:47 2024 GMT)",
+            ],
         )
 
     @patch("argo_scg.sensu.subprocess.check_output")
     def test_filter_events_by_status_if_empty_list(self, mock_subprocess):
-        mock_subprocess.return_value = \
-            json.dumps(mock_events_ctl).encode("utf-8")
+        mock_subprocess.return_value = json.dumps(mock_events_ctl).encode("utf-8")
         events = self.sensuctl.filter_events(status=1)
         self.assertEqual(
-            events, [
+            events,
+            [
                 "Entity    Metric    Status    Executed             Output",
-                "____________________________________________________________"
-            ]
+                "____________________________________________________________",
+            ],
         )


### PR DESCRIPTION
Wrapped the logic for adding each tenant into a try/catch block. Should allow for other tenants in the same namespace to be initialized properly.